### PR TITLE
Get*Project should always return something

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbProperty",
     "Description": "Database Properties (DAO)",
-    "VCS Version": "3.1.11"
+    "VCS Version": "3.1.12"
   },
   "Items": {
     "AccessVersion": {
@@ -42,7 +42,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "3.1.11",
+      "Value": "3.1.12",
       "Type": 10
     },
     "Auto Compact": {
@@ -118,7 +118,7 @@
       "Type": 4
     },
     "ProjVer": {
-      "Value": 119,
+      "Value": 141,
       "Type": 3
     },
     "QueryTimeout": {
@@ -169,6 +169,10 @@
       "Value": true,
       "Type": 1
     },
+    "Theme Resource Name": {
+      "Value": "Office Theme",
+      "Type": 10
+    },
     "Themed Form Controls": {
       "Value": 1,
       "Type": 4
@@ -194,7 +198,7 @@
       "Type": 2
     },
     "Version": {
-      "Value": "14.0",
+      "Value": "12.0",
       "Type": 12
     },
     "WebDesignMode": {

--- a/Version Control.accda.src/documents.json
+++ b/Version Control.accda.src/documents.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbDocument",
     "Description": "Database Documents Properties (DAO)",
-    "VCS Version": "3.1.11"
+    "VCS Version": "3.1.12"
   },
   "Items": {
     "Databases": {

--- a/Version Control.accda.src/forms/frmVCSMain.bas
+++ b/Version Control.accda.src/forms/frmVCSMain.bas
@@ -1,4 +1,4 @@
-Version =20
+Version =21
 VersionRequired =20
 Begin Form
     PopUp = NotDefault
@@ -21,7 +21,7 @@ Begin Form
     Top =2430
     Right =18945
     Bottom =14175
-    DatasheetGridlinesColor =14806254
+    DatasheetGridlinesColor =15132391
     RecSrcDt = Begin
         0x79e78b777268e540
     End
@@ -33,9 +33,6 @@ Begin Form
     End
     OnLoad ="[Event Procedure]"
     AllowDatasheetView =0
-    AllowPivotTableView =0
-    AllowPivotChartView =0
-    AllowPivotChartView =0
     FilterOnLoad =0
     ShowPageMargins =0
     DisplayOnSharePointSite =1

--- a/Version Control.accda.src/forms/frmVCSOptions.bas
+++ b/Version Control.accda.src/forms/frmVCSOptions.bas
@@ -1,4 +1,4 @@
-Version =20
+Version =21
 VersionRequired =20
 Begin Form
     PopUp = NotDefault
@@ -21,7 +21,7 @@ Begin Form
     Top =2430
     Right =14115
     Bottom =14175
-    DatasheetGridlinesColor =14806254
+    DatasheetGridlinesColor =15132391
     RecSrcDt = Begin
         0x79e78b777268e540
     End
@@ -33,9 +33,6 @@ Begin Form
     End
     OnLoad ="[Event Procedure]"
     AllowDatasheetView =0
-    AllowPivotTableView =0
-    AllowPivotChartView =0
-    AllowPivotChartView =0
     FilterOnLoad =0
     ShowPageMargins =0
     DisplayOnSharePointSite =1
@@ -816,7 +813,7 @@ Begin Form
                                     Top =5580
                                     Width =2340
                                     TabIndex =10
-                                    ForeColor =16711680
+                                    ForeColor =12673797
                                     Name ="cmdExplainOptions"
                                     Caption ="Explain options..."
                                     HyperlinkAddress ="https://github.com/joyfullservice/msaccess-vcs-integration/wiki/Documentation#op"
@@ -1074,7 +1071,7 @@ Begin Form
                                     Height =315
                                     TabIndex =4
                                     BorderColor =10921638
-                                    ForeColor =4138256
+                                    ForeColor =3484194
                                     Name ="cboTableDataSaveType"
                                     RowSourceType ="Value List"
                                     GridlineColor =10921638
@@ -1247,7 +1244,7 @@ Begin Form
                                     FontSize =10
                                     BackColor =14262935
                                     BorderColor =15321539
-                                    ForeColor =16711680
+                                    ForeColor =12673797
                                     Name ="lblAddOtherTable"
                                     Caption ="Other..."
                                     OnClick ="[Event Procedure]"
@@ -1457,7 +1454,7 @@ Begin Form
                                     Top =4860
                                     Width =1560
                                     TabIndex =1
-                                    ForeColor =16711680
+                                    ForeColor =12673797
                                     Name ="cmdEncryptionDetails"
                                     Caption ="Details..."
                                     HyperlinkAddress ="https://github.com/joyfullservice/msaccess-vcs-integration/wiki/Encryption"
@@ -2019,7 +2016,7 @@ Begin Form
                     Top =1260
                     Width =1560
                     TabIndex =3
-                    ForeColor =16711680
+                    ForeColor =12673797
                     Name ="cmdSeeDocs"
                     Caption ="See Docs..."
                     HyperlinkAddress ="https://github.com/joyfullservice/msaccess-vcs-integration/wiki/Documentation"

--- a/Version Control.accda.src/modules/clsDbRelation.bas
+++ b/Version Control.accda.src/modules/clsDbRelation.bas
@@ -177,7 +177,7 @@ Private Sub ImportRelation(ByRef filePath As String, Optional ByRef appInstance 
     Dim newRelation As Relation
     Set newRelation = thisDb.CreateRelation(fileLines(1), fileLines(2), fileLines(3), fileLines(0))
     
-    Dim newField As Field
+    Dim newField As DAO.Field
     Dim thisLine As Long
     For thisLine = 4 To UBound(fileLines)
         If "Field = Begin" = fileLines(thisLine) Then

--- a/Version Control.accda.src/modules/clsDbVbeProject.bas
+++ b/Version Control.accda.src/modules/clsDbVbeProject.bas
@@ -68,7 +68,20 @@ Private Sub IDbComponent_Import(strFile As String)
     With GetVBProjectForCurrentDB
         .Name = dNZ(dProject, "Items\Name")
         .Description = dNZ(dProject, "Items\Description")
+        
+        ' Setting the HelpContextId can throw random automation errors.
+        ' The setting does change despite the error.
+        Dim HelpID As Variant
+        HelpID = dNZ(dProject, "Items\HelpContextId")
+        On Error Resume Next
         .HelpContextId = dNZ(dProject, "Items\HelpContextId")
+        If Err.Number <> 0 Then
+            ' If we failed to set the ID then it was a real error, throw it
+            If .HelpContextId <> HelpID Then Err.Raise Err.Number, , Err.Description
+            Err.Clear
+        End If
+        On Error GoTo 0
+        
         .HelpFile = dNZ(dProject, "Items\HelpFile")
         ' // Read-only properties
         '.FileName = dNZ(dProject, "Items\FileName")

--- a/Version Control.accda.src/modules/modFunctions.bas
+++ b/Version Control.accda.src/modules/modFunctions.bas
@@ -1194,23 +1194,8 @@ End Function
 '
 Public Function GetVBProjectForCurrentDB() As VBProject
 
-    Dim objProj As Object
-    Dim strPath As String
-    
-    strPath = CurrentProject.FullName
-    If VBE.ActiveVBProject.FileName = strPath Then
-        ' Use currently active project
-        Set GetVBProjectForCurrentDB = VBE.ActiveVBProject
-    Else
-        ' Search for project with matching filename.
-        For Each objProj In VBE.VBProjects
-            If objProj.FileName = strPath Then
-                Set GetVBProjectForCurrentDB = objProj
-                Exit For
-            End If
-        Next objProj
-    End If
-    
+    Set GetVBProjectForCurrentDB = GetProjectByName(CurrentProject.FullName)
+
 End Function
 
 
@@ -1223,23 +1208,25 @@ End Function
 '
 Public Function GetCodeVBProject() As VBProject
 
+    Set GetCodeVBProject = GetProjectByName(CodeProject.FullName)
+
+End Function
+
+Private Function GetProjectByName(ByVal strPath As String) As VBProject
     Dim objProj As VBIDE.VBProject
-    Dim strPath As String
+        
+    ' Use currently active project by default
+    Set GetProjectByName = VBE.ActiveVBProject
     
-    strPath = CodeProject.FullName
-    If VBE.ActiveVBProject.FileName = strPath Then
-        ' Use currently active project
-        Set GetCodeVBProject = VBE.ActiveVBProject
-    Else
+    If VBE.ActiveVBProject.FileName <> strPath Then
         ' Search for project with matching filename.
         For Each objProj In VBE.VBProjects
             If objProj.FileName = strPath Then
-                Set GetCodeVBProject = objProj
+                Set GetProjectByName = objProj
                 Exit For
             End If
         Next objProj
     End If
-
 End Function
 
 

--- a/Version Control.accda.src/modules/modImportExport.bas
+++ b/Version Control.accda.src/modules/modImportExport.bas
@@ -255,7 +255,7 @@ Public Sub Build(strSourceFolder As String)
     ' Show final output and save log
     Log.Spacer
     Log.Add "Done. (" & Round(Timer - sngStart, 2) & " seconds)"
-    Log.SaveFile Options.GetExportFolder & "\Import.log"
+    Log.SaveFile FSO.BuildPath(Options.GetExportFolder, "Import.log")
 
     DoCmd.Hourglass False
     If Forms.Count > 0 Then

--- a/Version Control.accda.src/nav-pane-groups.json
+++ b/Version Control.accda.src/nav-pane-groups.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbNavPaneGroup",
     "Description": "Navigation Pane Custom Groups",
-    "VCS Version": "3.1.11"
+    "VCS Version": "3.1.12"
   },
   "Items": {
     "Groups": [

--- a/Version Control.accda.src/vbe-project.json
+++ b/Version Control.accda.src/vbe-project.json
@@ -2,14 +2,14 @@
   "Info": {
     "Class": "clsDbVbeProject",
     "Description": "VBE Project",
-    "VCS Version": "3.1.11"
+    "VCS Version": "3.1.12"
   },
   "Items": {
     "Name": "MSAccessVCS",
-    "Description": "Version 3.1.11 deployed on 5/26/2020",
+    "Description": "Version 3.1.12 deployed on 5/26/2020",
     "FileName": "rel:Version Control.accda",
     "HelpContextId": 0,
-    "HelpFile": "",
+    "HelpFile": "87380012",
     "Mode": 0,
     "Protection": 0,
     "Type": 100

--- a/Version Control.accda.src/vbe-references.json
+++ b/Version Control.accda.src/vbe-references.json
@@ -2,9 +2,33 @@
   "Info": {
     "Class": "clsDbVbeReference",
     "Description": "VBE References",
-    "VCS Version": "3.1.11"
+    "VCS Version": "3.1.12"
   },
   "Items": {
+    "IWshRuntimeLibrary": {
+      "GUID": "{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}",
+      "Version": "1.0"
+    },
+    "VBScript_RegExp_55": {
+      "GUID": "{3F4DACA7-160D-11D2-A8E9-00104B365C9F}",
+      "Version": "5.5"
+    },
+    "Scripting": {
+      "GUID": "{420B2830-E718-11CF-893D-00A0C9054228}",
+      "Version": "1.0"
+    },
+    "VBIDE": {
+      "GUID": "{0002E157-0000-0000-C000-000000000046}",
+      "Version": "5.3"
+    },
+    "Office": {
+      "GUID": "{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}",
+      "Version": "2.8"
+    },
+    "ADODB": {
+      "GUID": "{B691E011-1797-432E-907A-4D8C69339129}",
+      "Version": "6.1"
+    },
     "stdole": {
       "GUID": "{00020430-0000-0000-C000-000000000046}",
       "Version": "2.0"
@@ -12,30 +36,6 @@
     "DAO": {
       "GUID": "{4AC9E1DA-5BAD-4AC7-86E3-24F4CDCECA28}",
       "Version": "12.0"
-    },
-    "ADODB": {
-      "GUID": "{B691E011-1797-432E-907A-4D8C69339129}",
-      "Version": "6.1"
-    },
-    "Office": {
-      "GUID": "{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}",
-      "Version": "2.5"
-    },
-    "VBIDE": {
-      "GUID": "{0002E157-0000-0000-C000-000000000046}",
-      "Version": "5.3"
-    },
-    "Scripting": {
-      "GUID": "{420B2830-E718-11CF-893D-00A0C9054228}",
-      "Version": "1.0"
-    },
-    "VBScript_RegExp_55": {
-      "GUID": "{3F4DACA7-160D-11D2-A8E9-00104B365C9F}",
-      "Version": "5.5"
-    },
-    "IWshRuntimeLibrary": {
-      "GUID": "{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}",
-      "Version": "1.0"
     }
   }
 }

--- a/Version Control.accda.src/vcs-options.json
+++ b/Version Control.accda.src/vcs-options.json
@@ -1,8 +1,8 @@
 {
   "Info": {
-    "AddinVersion": "3.1.11",
-    "AccessVersion": "14.0 32-bit",
-    "Hash": "@{7206d6328b5c80f8ceae447eb65c6abd23260569ff1ffc94}"
+    "AddinVersion": "3.1.12",
+    "AccessVersion": "16.0 64-bit",
+    "Hash": "@{57a4c8dff37fbeb4b3883527a7f36ea6db6f550f6d45a5e7}"
   },
   "Options": {
     "ExportFolder": "",


### PR DESCRIPTION
Use the same logic for GetCodeVBProject and GetVBProjectForCurrentDB and always return a project. I was hitting an edge case where it would fail to find the project and return nothing.
Use FSO.BuildPath to fix Log file path (remove redundant slash)
Handle HelpContextId errors, Closes #32
Use `With` pattern to automatically handle objects