### PR TITLE
PtrSafe for 64-bit

### DIFF
--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbProperty",
     "Description": "Database Properties (DAO)",
-    "VCS Version": "3.1.26"
+    "VCS Version": "3.1.27"
   },
   "Items": {
     "AccessVersion": {
@@ -42,7 +42,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "3.1.26",
+      "Value": "3.1.27",
       "Type": 10
     },
     "Auto Compact": {
@@ -106,7 +106,7 @@
       "Type": 4
     },
     "NavPane Width": {
-      "Value": 215,
+      "Value": 505,
       "Type": 4
     },
     "Never Cache": {
@@ -118,7 +118,7 @@
       "Type": 4
     },
     "ProjVer": {
-      "Value": 119,
+      "Value": 141,
       "Type": 3
     },
     "QueryTimeout": {

--- a/Version Control.accda.src/documents.json
+++ b/Version Control.accda.src/documents.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbDocument",
     "Description": "Database Documents Properties (DAO)",
-    "VCS Version": "3.1.26"
+    "VCS Version": "3.1.27"
   },
   "Items": {
     "Databases": {

--- a/Version Control.accda.src/nav-pane-groups.json
+++ b/Version Control.accda.src/nav-pane-groups.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbNavPaneGroup",
     "Description": "Navigation Pane Custom Groups",
-    "VCS Version": "3.1.26"
+    "VCS Version": "3.1.27"
   },
   "Items": {
     "Groups": [

--- a/Version Control.accda.src/vbe-project.json
+++ b/Version Control.accda.src/vbe-project.json
@@ -2,13 +2,13 @@
   "Info": {
     "Class": "clsDbVbeProject",
     "Description": "VBE Project",
-    "VCS Version": "3.1.26"
+    "VCS Version": "3.1.27"
   },
   "Items": {
     "Name": "MSAccessVCS",
-    "Description": "Version 3.1.26 deployed on 5/28/2020",
+    "Description": "Version 3.1.27 deployed on 5/29/2020",
     "FileName": "rel:Version Control.accda",
-    "HelpFile": "",
+    "HelpFile": "87380012",
     "HelpContextId": 0,
     "Mode": 0,
     "Protection": 0,

--- a/Version Control.accda.src/vbe-references.json
+++ b/Version Control.accda.src/vbe-references.json
@@ -2,7 +2,7 @@
   "Info": {
     "Class": "clsDbVbeReference",
     "Description": "VBE References",
-    "VCS Version": "3.1.26"
+    "VCS Version": "3.1.27"
   },
   "Items": {
     "stdole": {
@@ -27,7 +27,7 @@
     },
     "Office": {
       "GUID": "{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}",
-      "Version": "2.5"
+      "Version": "2.8"
     },
     "Scripting": {
       "GUID": "{420B2830-E718-11CF-893D-00A0C9054228}",

--- a/Version Control.accda.src/vcs-options.json
+++ b/Version Control.accda.src/vcs-options.json
@@ -1,8 +1,8 @@
 {
   "Info": {
-    "AddinVersion": "3.1.26",
-    "AccessVersion": "14.0 32-bit",
-    "Hash": "@{7206d6328b5c80f8ceae447eb65c6abd23260569ff1ffc94}"
+    "AddinVersion": "3.1.27",
+    "AccessVersion": "16.0 64-bit",
+    "Hash": "@{57a4c8dff37fbeb4b3883527a7f36ea6db6f550f6d45a5e7}"
   },
   "Options": {
     "ExportFolder": "",


### PR DESCRIPTION
Unit test for text coversions was failing with new unicode support patch. I fixed it by changing the length of a byte array that was truncating the final CRLF off the end of the file.

This now compiles on 64-bit and passes all unit tests.