### PR TITLE
Add option to force import of original SQL for queries

### DIFF
--- a/Version Control.accda.src/forms/frmVCSOptions.bas
+++ b/Version Control.accda.src/forms/frmVCSOptions.bas
@@ -1403,7 +1403,7 @@ Begin Form
                                 Begin Label
                                     OverlapFlags =247
                                     Left =1140
-                                    Top =2340
+                                    Top =2100
                                     Width =7860
                                     Height =2445
                                     BorderColor =8355711
@@ -1418,11 +1418,62 @@ Begin Form
                                         "ct."
                                     GridlineColor =10921638
                                     LayoutCachedLeft =1140
-                                    LayoutCachedTop =2340
+                                    LayoutCachedTop =2100
                                     LayoutCachedWidth =9000
                                     LayoutCachedHeight =4785
                                     ForeThemeColorIndex =-1
                                     ForeTint =100.0
+                                End
+                                Begin CheckBox
+                                    OverlapFlags =247
+                                    Left =1140
+                                    Top =4885
+                                    TabIndex =1
+                                    BorderColor =10921638
+                                    Name ="chkForceImportOriginalQuerySQL"
+                                    GridlineColor =10921638
+
+                                    LayoutCachedLeft =1140
+                                    LayoutCachedTop =4885
+                                    LayoutCachedWidth =1400
+                                    LayoutCachedHeight =5125
+                                    Begin
+                                        Begin Label
+                                            OverlapFlags =247
+                                            Left =1447
+                                            Top =4830
+                                            Width =3705
+                                            Height =315
+                                            BorderColor =8355711
+                                            ForeColor =5324600
+                                            Name ="Étiquette116"
+                                            Caption ="Force import of original SQL for queries"
+                                            GridlineColor =10921638
+                                            LayoutCachedLeft =1447
+                                            LayoutCachedTop =4830
+                                            LayoutCachedWidth =5152
+                                            LayoutCachedHeight =5145
+                                            ForeThemeColorIndex =-1
+                                            ForeTint =100.0
+                                        End
+                                    End
+                                End
+                                Begin Label
+                                    OverlapFlags =247
+                                    Left =5197
+                                    Top =4874
+                                    Width =4620
+                                    Height =240
+                                    FontSize =10
+                                    BorderColor =8355711
+                                    ForeColor =8355711
+                                    Name ="Étiquette117"
+                                    Caption ="(\"Save Query SQL\" option needed when exporting)"
+                                    GridlineColor =10921638
+                                    LayoutCachedLeft =5197
+                                    LayoutCachedTop =4874
+                                    LayoutCachedWidth =9817
+                                    LayoutCachedHeight =5114
                                 End
                             End
                         End

--- a/Version Control.accda.src/modules/clsDbQuery.bas
+++ b/Version Control.accda.src/modules/clsDbQuery.bas
@@ -48,16 +48,41 @@ Private Sub IDbComponent_Export()
     
 End Sub
 
-
 '---------------------------------------------------------------------------------------
 ' Procedure : Import
-' Author    : Adam Waller
-' Date      : 4/23/2020
+' Author    : Adam Waller / Indigo
+' Date      : 10/24/2020
 ' Purpose   : Import the individual database component from a file.
 '---------------------------------------------------------------------------------------
 '
 Private Sub IDbComponent_Import(strFile As String)
-    LoadComponentFromText acQuery, GetObjectNameFromFileName(strFile), strFile
+    Dim dbs As DAO.Database
+    Dim strQueryName As String
+    Dim strFileSql As String
+    Dim strSql As String
+    
+    strQueryName = GetObjectNameFromFileName(strFile)
+    
+    LoadComponentFromText acQuery, strQueryName, strFile
+    
+    ' Import exact query from SQL (if using that option)
+    If Options.SaveQuerySQL Then
+        Set dbs = CurrentDb
+        strFileSql = Left$(strFile, Len(strFile) - 4) & ".sql" ' Replace .bas extension with .sql to get file content
+        
+        ' Tries to get SQL content from the SQL file previously exported
+        strSql = vbNullString
+On Error Resume Next
+        strSql = ReadFile(strFileSql)
+On Error GoTo 0
+
+        If strSql <> vbNullString And strSql <> "" Then
+            dbs.QueryDefs(strQueryName).SQL = strSql
+            Log.Add "  Set SQL query for " & strQueryName, Options.ShowDebug
+        Else
+            Log.Add "  Couldn't get original SQL query for " & strQueryName
+        End If
+    End If
 End Sub
 
 

--- a/Version Control.accda.src/modules/clsDbQuery.bas
+++ b/Version Control.accda.src/modules/clsDbQuery.bas
@@ -65,8 +65,8 @@ Private Sub IDbComponent_Import(strFile As String)
     
     LoadComponentFromText acQuery, strQueryName, strFile
     
-    ' Import exact query from SQL (if using that option)
-    If Options.SaveQuerySQL Then
+    ' Import exact query from SQL
+    If Options.ForceImportOriginalQuerySQL Then
         Set dbs = CurrentDb
         strFileSql = Left$(strFile, Len(strFile) - 4) & ".sql" ' Replace .bas extension with .sql to get file content
         

--- a/Version Control.accda.src/modules/clsOptions.bas
+++ b/Version Control.accda.src/modules/clsOptions.bas
@@ -19,6 +19,7 @@ Public ShowDebug As Boolean
 Public UseFastSave As Boolean
 Public SavePrintVars As Boolean
 Public SaveQuerySQL As Boolean
+Public ForceImportOriginalQuerySQL As Boolean
 Public SaveTableSQL As Boolean
 Public StripPublishOption As Boolean
 Public AggressiveSanitize As Boolean
@@ -67,6 +68,7 @@ Public Sub LoadDefaults()
         .UseFastSave = True
         .SavePrintVars = True
         .SaveQuerySQL = True
+        .ForceImportOriginalQuerySQL = False
         .SaveTableSQL = True
         .StripPublishOption = True
         .AggressiveSanitize = True
@@ -420,6 +422,7 @@ Private Sub Class_Initialize()
         .Add "UseFastSave"
         .Add "SavePrintVars"
         .Add "SaveQuerySQL"
+        .Add "ForceImportOriginalQuerySQL"
         .Add "SaveTableSQL"
         .Add "StripPublishOption"
         .Add "AggressiveSanitize"

--- a/Version Control.accda.src/modules/modFunctions.bas
+++ b/Version Control.accda.src/modules/modFunctions.bas
@@ -735,6 +735,34 @@ End Sub
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : ReadFile
+' Author    : Adam Waller / Indigo
+' Date      : 10/24/2020
+' Purpose   : Read text file.
+'           : Read in UTF-8 encoding, removing a BOM if found at start of file.
+'---------------------------------------------------------------------------------------
+'
+Public Function ReadFile(strPath As String) As String
+
+    Dim stm As ADODB.Stream
+    Dim strText As String
+    
+    Set stm = New ADODB.Stream
+    With stm
+        .Charset = "UTF-8"
+        .Open
+        .LoadFromFile strPath
+    End With
+    
+    strText = stm.ReadText(adReadAll)
+    
+    ' Skip past any UTF-8 BOM header
+    If Left$(strText, 3) = UTF8_BOM Then strText = Mid$(strText, 4)
+    
+    ReadFile = strText
+End Function
+
+'---------------------------------------------------------------------------------------
 ' Procedure : WriteFile
 ' Author    : Adam Waller
 ' Date      : 1/23/2019


### PR DESCRIPTION
Fixes #76 

As discussed, this PR adds:
 - A new flag `ForceImportOriginalQuerySQL`, FALSE by default, in BUILD option tab
    ![image](https://user-images.githubusercontent.com/7137528/97079463-64117000-15f4-11eb-9232-fbbd9286e93b.png)
 - If this flag is set, after importing the *.bas file, tries to open the *.sql file and set the `QueryDefs.SQL` property.

It works quite well after some testing, and no issue regarding to subqueries.