### PR TITLE
Check TableDefs.Connect to determine if table is local

### DIFF
--- a/Version Control.accda.src/forms/frmVCSOptions.bas
+++ b/Version Control.accda.src/forms/frmVCSOptions.bas
@@ -3301,7 +3301,7 @@ Private Sub LoadTableList()
             ' Read table attributes
             blnHidden = Application.GetHiddenAttribute(acTable, tbl.Name)
             blnSystem = (tbl.Attributes And dbSystemObject)
-            blnLocal = isLocalTable(tbl)
+            blnLocal = isLocalTable(tbl.Name)
             blnOther = False    ' Other represents tables not in this database.
             ' Add array record to represent table.
             AddUpdateTableInList tbl.Name, vbNullString, blnHidden, blnSystem, blnOther, blnLocal
@@ -3329,14 +3329,10 @@ End Sub
 ' Purpose   : Check wether a table is a local table (= not a linked table)
 '---------------------------------------------------------------------------------------
 '
-Private Function isLocalTable(ByRef tbl As AccessObject)
-    If tbl.Attributes And dbAttachedODBC Then
-        isLocalTable = False
-    ElseIf tbl.Attributes And dbAttachedTable Then
-        isLocalTable = False
-    Else
-        isLocalTable = True
-    End If
+Private Function isLocalTable(ByVal tblName As String)
+On Error Resume Next
+    isLocalTable = False
+    isLocalTable = Len(CurrentDb.TableDefs(tblName).Connect) = 0
 End Function
 
 


### PR DESCRIPTION
When looking at the Testing.accdb file, I noticed the linked CSV and linked ACCDB were wrongly identified as "local".

I decided to stop using the `AllTables.Attributes` property (which is not really documented) and simply check the `TableDefs.Connect` property.

Now it works better 😸 

![image](https://user-images.githubusercontent.com/7137528/99144350-4e2c2380-2665-11eb-8fe0-2585f90415bb.png)

