### PR TITLE
Switch which are the default; trust single file vs whole folder seems…

### DIFF
--- a/Version Control.accda.src/forms/frmVCSInstall.bas
+++ b/Version Control.accda.src/forms/frmVCSInstall.bas
@@ -1573,9 +1573,6 @@ End Sub
 '
 Private Sub cmdInstall_Click()
 
-    ' Check trusted location
-    If chkAddTrustedLocation Then modInstall.VerifyTrustedLocation
-    
     ' Main install
     If modInstall.InstallVCSAddin Then
     
@@ -1586,7 +1583,8 @@ Private Sub cmdInstall_Click()
                 
         ' Run post-install processes.
         CheckForLegacyInstall
-        VerifyTrustedLocation
+        ' Check trusted location
+        If chkAddTrustedLocation Then modInstall.VerifyTrustedLocation
     
         ' Relaunch from install folder to allow user to trust file.
         If chkOpenAfterInstall Then modInstall.OpenAddinFile GetAddinFileName, CodeProject.FullName

--- a/Version Control.accda.src/forms/frmVCSInstall.bas
+++ b/Version Control.accda.src/forms/frmVCSInstall.bas
@@ -1344,7 +1344,7 @@ Begin Form
                     TabIndex =2
                     BorderColor =10921638
                     Name ="chkAddTrustedLocation"
-                    DefaultValue ="True"
+                    DefaultValue ="False"
                     GridlineColor =10921638
 
                     LayoutCachedLeft =4440
@@ -1381,7 +1381,7 @@ Begin Form
                     TabIndex =3
                     BorderColor =10921638
                     Name ="chkOpenAfterInstall"
-                    DefaultValue ="False"
+                    DefaultValue ="True"
                     GridlineColor =10921638
 
                     LayoutCachedLeft =4440


### PR DESCRIPTION
This opts to open the file to see if it's trusted first, instead of trusting the whole folder (principle of least privilege); I found that in my environment, even if the folder is trusted, the file needs to be; this eschews having to have a whole folder trusted where simply opening the file solves the trust problem.

I think this is the last step in #120?

(re-pull because my sleep-addled brain didn't notice that this was pulling into master and not dev...oops).