### PR TITLE
Add binary import in class "dbs-properties.json"

### DIFF
--- a/Version Control.accda.src/modules/clsDbProperty.bas
+++ b/Version Control.accda.src/modules/clsDbProperty.bas
@@ -94,7 +94,14 @@ Private Sub IDbComponent_Import(strFile As String)
     Dim varValue As Variant
     Dim strDecrypted As String
     Dim blnAdd As Boolean
-    
+    Dim varItem As Variant
+    Dim bArray() As Byte
+    Dim i As Long
+    Dim bUpdate As Boolean
+
+    ' Only import files with the correct extension.
+    If Not strFile Like "*.json" Then Exit Sub
+
     Set dbs = CurrentDb
     
     ' Pull a list of the existing properties so we know whether
@@ -117,12 +124,22 @@ Private Sub IDbComponent_Import(strFile As String)
                 Case "Connection", "Name", "Version", "CollatingOrder" ' Can't set these properties
                 Case Else
                     blnAdd = False
-                    varValue = dItems(varKey)("Value")
-                    ' Check for encryption
-                    strDecrypted = Decrypt(CStr(varValue))
-                    If CStr(varValue) <> strDecrypted Then varValue = strDecrypted
-                    ' Check for relative path
-                    If Left$(varValue, 4) = "rel:" Then varValue = GetPathFromRelative(CStr(varValue))
+                    bUpdate = False
+                    ' Check if value is as Collection
+                    If Not TypeOf dItems(varKey)("Value") Is Collection Then
+                        varValue = dItems(varKey)("Value")
+                        ' Check for encryption
+                        strDecrypted = Decrypt(CStr(varValue))
+                        If CStr(varValue) <> strDecrypted Then varValue = strDecrypted
+                        ' Check for relative path
+                        If Left$(varValue, 4) = "rel:" Then varValue = GetPathFromRelative(CStr(varValue))
+                    Else
+                        ReDim bArray(0 To dItems(varKey)("Value").Count - 1)
+                        For Each varItem In dItems(varKey)("Value")
+                            bArray(i) = CByte(varItem)
+                            i = i + 1
+                        Next
+                    End If
                     ' Check for existing value
                     If dExisting.Exists(varKey) Then
                         If dItems(varKey)("Type") <> dExisting(varKey)(1) Then
@@ -130,22 +147,55 @@ Private Sub IDbComponent_Import(strFile As String)
                             dbs.Properties.Delete varKey
                             blnAdd = True
                         Else
-                            ' Check the value, and update if different
-                            If varValue <> dExisting(varKey)(0) Then
-                                ' Update value of existing property if different.
-                                dbs.Properties(varKey).Value = varValue
+                            ' Check if value is a Collection
+                            If Not TypeOf dItems(varKey)("Value") Is Collection Then
+                                ' Check the value, and update if different
+                                If varValue <> dExisting(varKey)(0) Then
+                                    ' Update value of existing property if different.
+                                    dbs.Properties(varKey).Value = varValue
+                                End If
+                            Else
+                                ' Check the arrays, and update if different
+                                If (LBound(bArray) <> LBound(dExisting(varKey)(0))) Or (UBound(bArray) <> UBound(dExisting(varKey)(0))) Then
+                                    ' Different size
+                                    bUpdate = True
+                                Else
+                                    ' Same size
+                                    ' Check content
+                                    For i = LBound(bArray) To UBound(bArray)
+                                        If (bArray(i) <> dExisting(varKey)(0)(i)) Then
+                                            bUpdate = True
+                                            Exit For
+                                        End If
+                                    Next
+                                End If
+                                If bUpdate Then
+                                    ' Update value of existing property if different.
+                                    dbs.Properties(varKey).Value = bArray
+                                End If
                             End If
                         End If
                     Else
                         ' Add properties that don't exist.
                         blnAdd = True
                     End If
-					' Can't add a text property with a null value. See issue #126
-                    If varValue = vbNullChar And dItems(varKey)("Type") = 10 Then blnAdd = False
+                    
+                    ' Can't add a text property with a null value. See issue #126
+                    If dItems(varKey)("Type") = 10 Then
+                        If varValue = vbNullChar Then blnAdd = False
+                    End If
                     ' Add the property if the flag has been set.
                     If blnAdd Then
-                        ' Create property, then append to collection
-                        Set prp = dbs.CreateProperty(varKey, dItems(varKey)("Type"), varValue)
+                        ' Check if value is a Collection
+                        If Not TypeOf dItems(varKey)("Value") Is Collection Then
+                            ' Create property
+                            Set prp = dbs.CreateProperty(varKey, dItems(varKey)("Type"), varValue)
+                        Else
+                            ' Create property from array
+                            Set prp = dbs.CreateProperty(varKey, dItems(varKey)("Type"), bArray)
+                        End If
+                        
+                        ' Append property to collection
                         dbs.Properties.Append prp
                     End If
             End Select


### PR DESCRIPTION
See #153
It could be possible that data (`vbBinary`) is stored in the properties of a database, e.g. LicenceKeys

With this patch it is possible to import those `vbBinary` data, with is stored in dbs-properties.json as a byte-array

Greetings
TanarRi