### PR TITLE
The number of lines in a CodeModule is dynamic.

### DIFF
--- a/Version Control.accda.src/modules/modHash.bas
+++ b/Version Control.accda.src/modules/modHash.bas
@@ -261,7 +261,7 @@ Public Function GetCodeModuleHash(intType As eDatabaseComponentType, strName As 
         ' Output the hash
         If Not cmpItem Is Nothing Then
             With cmpItem.CodeModule
-                strHash = GetStringHash(.Lines(1, 99999), intLength)
+                strHash = GetStringHash(.Lines(1, .CountOfLines + .CountOfDeclarationLines), intLength)
             End With
         End If
     


### PR DESCRIPTION
This hard-coded number of lines makes me feel uneasy. Although it's unlikely that you will have a module that is over 99,999 lines I think it's better to use the properties available to us to calculate the number of lines in the module. I have tested this on the test DB and my main project.