### PR TITLE
Added and enhanced testing for class clsConcat

### DIFF
--- a/Version Control.accda.src/modules/clsConcat.bas
+++ b/Version Control.accda.src/modules/clsConcat.bas
@@ -303,6 +303,8 @@ Public Sub SelfTest()
         Debug.Assert .GetStr = "1234567890"
         .Add "A"
         Debug.Assert .GetStr = "1234567890A"
+        .Remove 1
+        Debug.Assert .GetStr = "1234567890"
     End With
     
 End Sub

--- a/Version Control.accda.src/modules/modUnitTesting.bas
+++ b/Version Control.accda.src/modules/modUnitTesting.bas
@@ -214,3 +214,14 @@ TestExit:
 TestFail:
     Assert.Fail "Test raised an error: #" & Err.Number & " - " & Err.Description
 End Sub
+
+
+'@TestMethod("Concat")
+Private Sub TestConcat()
+    
+    Dim objConcat As clsConcat
+    
+    Set objConcat = New clsConcat
+    objConcat.SelfTest
+    Set objConcat = Nothing
+End Sub


### PR DESCRIPTION
At the moment there is a error in clsConcat.GetStr if the variable lngCurrentPos = 0

This will enhance the clsConcat.Selftest to raise an error.

clsConcat.GetStr has still to be fixed