### PR TITLE
add BOM check before encoding module files

### DIFF
--- a/Version Control.accda.src/modules/modVCSUtility.bas
+++ b/Version Control.accda.src/modules/modVCSUtility.bas
@@ -262,7 +262,7 @@ Public Sub LoadComponentFromText(intType As AcObjectType, _
         Case acModule
             ' Always convert from UTF-8 in case the file contains
             ' UTF-8 encoded characters but does not have a BOM.
-            blnConvert = True
+            If modEncoding.HasUtf8Bom(strFile) Then blnConvert = True
     End Select
     
     ' Only run conversion if needed.


### PR DESCRIPTION
I ran into a problem where importing ISO-1253 encoded module files would render 'æ', 'ø' and 'å' (and probably also other foreign characters) as questionmarks(?). 
My quick solution to this would be to check if the module source file was indeed an UTF-8 file before converting it.