### PR TITLE
Fix background color of frmVCSMain.txtDescription

### DIFF
--- a/Version Control.accda.src/forms/frmVCSMain.bas
+++ b/Version Control.accda.src/forms/frmVCSMain.bas
@@ -1291,6 +1291,7 @@ Begin Form
                     Height =2400
                     FontSize =10
                     TabIndex =3
+                    BackColor =15130848
                     ForeColor =5324600
                     Name ="txtDescription"
                     TextFormat =1
@@ -1300,6 +1301,7 @@ Begin Form
                     LayoutCachedTop =3300
                     LayoutCachedWidth =2760
                     LayoutCachedHeight =5700
+                    BackThemeColorIndex =-1
                     BorderThemeColorIndex =0
                     BorderTint =50.0
                     BorderShade =100.0


### PR DESCRIPTION
If the control frmVCSMain.txtDescription is selected the background will change from transparent to white.
This patch fixed it, so the background on selection is the same as the background of the form. For the user it seems the control is transparent