### PR TITLE
Remove excess declaration

### DIFF
--- a/Version Control.accda.src/modules/clsLog.cls
+++ b/Version Control.accda.src/modules/clsLog.cls
@@ -64,8 +64,6 @@ Public Sub Add(strText As String, Optional blnPrint As Boolean = True, _
     Optional blnNextOutputOnNewLine As Boolean = True, _
     Optional strColor As String = vbNullString, _
     Optional blnBold As Boolean = False)
-
-    Dim strHtml As String
     
     ' Add to log file output
     m_Log.Add strText, vbCrLf


### PR DESCRIPTION
@joyfullservice, this should just remove a single line. It isn't referred to anywhere; looks like it's a leftover or a placeholder for something that isn't there any more.