### PR TITLE
Performance Feature (CallStack!)

### DIFF
--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -56,7 +56,7 @@ Public Sub StartTiming()
 End Sub
 
 '---------------------------------------------------------------------------------------
-' Procedure : StartTiming
+' Procedure : CallStack
 ' Author    : hecon5
 ' Date      : 01/26/2022
 ' Purpose   : Return the call stack in operation.
@@ -77,6 +77,7 @@ Public Property Get CallStack() As String
         For CallStackPosition = 1 To m_colOpsCallStack.Count
             .Add CStr(m_colOpsCallStack(CallStackPosition))
         Next CallStackPosition
+        .Add m_strOperation
         .Remove 1 ' Remove last period so it doesn't look silly.
         CallStack = .GetStr
     End With

--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -51,10 +51,35 @@ Private m_colOpsCallStack As VBA.Collection
 '---------------------------------------------------------------------------------------
 '
 Public Sub StartTiming()
-    ResetAll
+    Reset
     m_Overall.Start = MicroTimer
 End Sub
 
+'---------------------------------------------------------------------------------------
+' Procedure : StartTiming
+' Author    : hecon5
+' Date      : 01/26/2022
+' Purpose   : Return the call stack in operation.
+'           : Adds major element "Component" if in use, and the trace of all minor
+'           : elements (Operations) affixed with a period. This facilitates use of
+'           : performance and because the VBA error may be returned before you expect
+'           : (or after...VBA can be fun!).
+'---------------------------------------------------------------------------------------
+'
+Public Property Get CallStack() As String
+    ' Iterates through whole call stack and spits out "where" you are.
+    Dim CallStackPosition As Long
+    Dim strCallStackElement As String
+    
+    With New clsConcat
+        .AppendOnAdd = "."
+        If m_strComponent <> vbNullString Then .Add m_strComponent
+        For CallStackPosition = 1 To m_colOpsCallStack.Count
+            .Add CStr(m_colOpsCallStack(CallStackPosition))
+        Next CallStackPosition
+        CallStack = .GetStr
+    End With
+End Property
 
 '---------------------------------------------------------------------------------------
 ' Procedure : ComponentStart
@@ -428,13 +453,13 @@ End Function
 
 
 '---------------------------------------------------------------------------------------
-' Procedure : ResetAll
+' Procedure : Reset
 ' Author    : Adam Waller
 ' Date      : 11/3/2020
 ' Purpose   : Reset all class values
 '---------------------------------------------------------------------------------------
 '
-Private Sub ResetAll()
+Public Sub Reset()
     Class_Initialize
     m_strComponent = vbNullString
     m_strOperation = vbNullString

--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -77,6 +77,7 @@ Public Property Get CallStack() As String
         For CallStackPosition = 1 To m_colOpsCallStack.Count
             .Add CStr(m_colOpsCallStack(CallStackPosition))
         Next CallStackPosition
+        .Remove 1 ' Remove last period so it doesn't look silly.
         CallStack = .GetStr
     End With
 End Property


### PR DESCRIPTION
@joyfullservice I ... borrowed... the performance from here and one of the features we've been trying out is using the performance as a call stack manager. It seems to work pretty well, but if you forget to end an operation it can lead to a little bit of tracking down. Upside of tracking down is you ensure closing performance items when you're done. 

We also added ability to clear the performance class as a public member; but this may not be needed everywhere. 

We've been using it by not passing the log / error source along in the log (or augmenting it with the whole call stack). This way the call stack only gets checked when we care, and doesn't get asked repeatedly along the way. I haven't noticed any long-term effects yet (we've only been toying with it for a few weeks yet). One thing that's been really nice about this is we added a prompt to the log, and push all msgbox style questions to users, which captures the response, question, and other pertinent data, and tells the user the breadcrumbs. This has been invaluable when rolling out new complex features to non-tech savvy users and figuring out what's not working when they say "I clicked on it!"

The one (possibly breaking issue) which may need to be addressed is if you have multiple forms open (or multiple copies of the same form) is how to handle the context switching element; not such a big deal on this, as it's fairly linear in operations (iterate through each element of each type in turn), so I'm kicking it here in case it's useful. When we deal with that, I'll share those, if you'd like.

Anyway, here it is; let me know your thoughts. If you like it, I can roll in these and a few other updates to the clsLog.cls I've been testing on my end.

# Use
## Instead of this: 
```VBA 
    (in clsLog.cls)
    public sub add(Add(strText As String, Optional blnPrint As Boolean = True, _
        Optional blnNextOutputOnNewLine As Boolean = True, _
        Optional strColor As String = vbNullString, _
        Optional blnBold As Boolean = False)
    ... stuff ...
   ...golly, I hope I remember where I was...
End Sub

Calling Example:
    log.Add "Something happened and I want to remember, here's where I was: " & ModuleName & ".somemadeupfunction"

   log.Error eelError, "Something bad happened and I want to remember.", ModuleName & ".somemadeupfunction"
```

## Do this:
```VBA 
    (in clsLog.cls)
    public sub add(Add(strText As String, Optional blnPrint As Boolean = True, _
        Optional blnNextOutputOnNewLine As Boolean = True, _
        Optional strColor As String = vbNullString, _
        Optional blnBold As Boolean = False)
    ' I already know where I am!
    ' Note: doing it here doesn't impact the console, because you want that "clean" :)
    m_log.Add strText, " Source:", Perf.CallStack, vbNewLine
     ' ... stuff ...
End Sub

Public Sub Error(eLevel As eErrorLevel, strDescription As String)
    ' Somewhere in here, add in the call stack as needed.
End Sub

Calling Example:
    log.Add "Something happened and I want to remember."

   log.Error eelError, "Something bad happened and I want to remember."
```