### PR TITLE
Bug fix for call stack trailing period if operation doesn't actually …

### DIFF
--- a/Version Control.accda.src/modules/clsPerformance.cls
+++ b/Version Control.accda.src/modules/clsPerformance.cls
@@ -87,8 +87,8 @@ Public Property Get CallStack() As String
             For lngCallStackPosition = 1 To this.CallStackItems.Count
                 .Add CStr(this.CallStackItems(lngCallStackPosition))
             Next lngCallStackPosition
-            .Add this.OperationName
-            .Remove 1 ' Remove trailing delimiter
+            If this.OperationName <> vbNullString Then .Add this.OperationName
+            If .Length > 0 Then .Remove 1 ' Remove trailing delimiter only if there's something to remove.
             CallStack = .GetStr
         End With
     End If


### PR DESCRIPTION
Fixes callstack issue where extra periods were left.

(cherry picked from commit c38686bc2df24e2aa60ed7d5159bae7948591d7d)