### PR TITLE
Updating to remove bug from closing form prior to hiding

### DIFF
--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -10,7 +10,7 @@ Attribute VB_Exposed = False
 '---------------------------------------------------------------------------------------
 ' Module    : clsLblProg
 ' Author    : Adam Waller
-' Date      : 2/17/2021
+' Date      : 4/21/2022
 ' Purpose   : Display a progress bar using three labels on a form
 '---------------------------------------------------------------------------------------
 Option Explicit
@@ -21,33 +21,39 @@ Option Compare Database
 ' object types in early binding.
 #Const APPLICATION_NAME = "Microsoft Access"
 
-#If APPLICATION_NAME = "Microsoft Access" Then
-    ' Use Access specific controls/sizing
-    Private Const sngOffset As Single = 15
-    Private mlblBack As Access.Label    ' existing label for back
-    Private mlblFront As Access.Label   ' label created for front
-    Private mlblCaption As Access.Label ' progress bar caption
-#Else
-    ' Generic VBA objects
-    Private Const sngOffset As Single = 1.5
-    Private mlblBack As Label           ' existing label for back
-    Private mlblFront As Label          ' label created for front
-    Private mlblCaption As Label        ' progress bar caption
-#End If
-
-
 ' Public properties
 Private m_Max As Double                    ' Maximum value of progress bar at 100%
 Public Smooth As Boolean                ' Set to true for smooth updates < 1%
+Public IncrementSize                    ' Custom size of increments
+Public HideCaption                      ' Optionally hide the percentage label
 
 ' Private properties
-Private mdblVal As Double               ' Current value of progress bar
-Private mdblFullWidth As Double         ' Width of front label at 100%
-Private mdblIncSize As Double           ' Icrement size
-Private mblnHideCap As Boolean          ' Show percent complete caption
-Private mobjParent As Object            ' Parent object of back label
-Private mdteLastUpdate As Date          ' Time last updated
-Private mblnNotSmooth As Boolean        ' Display smoothly by doevents after every update.
+Private Type udtProg
+
+    ' Application specific properties
+    #If APPLICATION_NAME = "Microsoft Access" Then
+        ' Use Access specific controls/sizing
+        lblBack As Access.Label         ' Existing label for back
+        lblFront As Access.Label        ' Label for moving bar
+        lblCaption As Access.Label      ' Progress bar caption
+    #Else
+        ' Generic VBA objects
+        lblBack As Label                ' Existing label for back
+        lblFront As Label               ' Label created for front
+        lblCaption As Label             ' Label created for caption
+    #End If
+
+    ' Shared private properties
+    dblValue As Double                  ' Current value of progress bar
+    dblDisplayed As Double              ' Displayed value
+    dblFullWidth As Double              ' Width of front label at 100%
+    sngOffset As Single                 ' Offset for front label
+    dblIncrementSize As Double          ' Increment size
+    blnHideCaption As Boolean           ' Show/hide percent complete caption
+    objParent As Object                 ' Parent object of back label
+    dteStartTime As Date                ' Time of first value change
+End Type
+Private this As udtProg
 
 
 '---------------------------------------------------------------------------------------
@@ -62,36 +68,38 @@ Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef
     Dim objParent As Object ' could be a form or tab control
     Dim frm As Form
     
-    Set mobjParent = BackLabel.Parent
-    Set mlblBack = BackLabel
+    Set this.objParent = BackLabel.Parent
+    Set this.lblBack = BackLabel
     
     #If APPLICATION_NAME = "Microsoft Access" Then
+        this.sngOffset = 15
         ' Use existing controls
-        Set mlblFront = FrontLabel
-        Set mlblCaption = CaptionLabel
+        Set this.lblFront = FrontLabel
+        Set this.lblCaption = CaptionLabel
     #Else
+        this.sngOffset = 1.5
         ' Create front controls dynamically
-        Set mlblFront = mobjParent.Controls.Add("forms.label.1", "", False)
-        Set mlblFront = CreateControl(GetParentFormName(BackLabel), acLabel, , BackLabel.Parent.Name)
-        Set mlblCaption = mobjParent.Controls.Add("forms.label.1", "", False)
-        Set mlblCaption = CreateControl(GetParentFormName(BackLabel), acLabel, , BackLabel.Parent)
+        Set this.lblFront = mobjParent.Controls.Add("forms.label.1", "", False)
+        Set this.lblFront = CreateControl(GetParentFormName(BackLabel), acLabel, , BackLabel.Parent.Name)
+        Set this.lblCaption = mobjParent.Controls.Add("forms.label.1", "", False)
+        Set this.lblCaption = CreateControl(GetParentFormName(BackLabel), acLabel, , BackLabel.Parent)
         ' Refresh display of parent form
-        mobjParent.Repaint
+        this.objParent.Repaint
     #End If
         
     ' Set properties for back label
-    With mlblBack
+    With this.lblBack
         .Visible = True
         .SpecialEffect = 2  ' sunken. Seems to lose when not visible.
     End With
     
     ' Set properties for front label
-    With mlblFront
-        mdblFullWidth = mlblBack.Width - (sngOffset * 2)
-        .Left = mlblBack.Left + sngOffset
-        .Top = mlblBack.Top + sngOffset
+    With this.lblFront
+        this.dblFullWidth = this.lblBack.Width - (this.sngOffset * 2)
+        .Left = this.lblBack.Left + this.sngOffset
+        .Top = this.lblBack.Top + this.sngOffset
         .Width = 0
-        .Height = mlblBack.Height - (sngOffset * 2)
+        .Height = this.lblBack.Height - (this.sngOffset * 2)
         .Caption = vbNullString
         .BackColor = 8388608
         .BackStyle = 1
@@ -99,48 +107,37 @@ Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef
     End With
     
     ' set properties for caption label
-    With mlblCaption
-        .Left = mlblBack.Left + 2
-        .Top = mlblBack.Top + 2
-        .Width = mlblBack.Width - 4
-        .Height = mlblBack.Height - 4
+    With this.lblCaption
+        .Left = this.lblBack.Left + 2
+        .Top = this.lblBack.Top + 2
+        .Width = this.lblBack.Width - 4
+        .Height = this.lblBack.Height - 4
         .TextAlign = 2 'fmTextAlignCenter
-        .TopMargin = sngOffset * 2
+        .TopMargin = this.sngOffset * 2
         .BackStyle = 0 'fmBackStyleTransparent
         .Caption = "0%"
         .Visible = Not Me.HideCaption
         .ForeColor = 16777215   ' white
     End With
-    If Me.Max = 0 Then Me.Max = 100
     Update
+
 End Sub
 
 
 '---------------------------------------------------------------------------------------
-' Procedure : Class_Terminate
-' Author    : Adam Waller
-' Date      : 2/17/2021
-' Purpose   : Remove temporary controls, if applicable
+' Procedure : Max Property
+' Author    : hecon5
+' Date      : 5/13/2022
+' Purpose   : Set maximum value for value.
 '---------------------------------------------------------------------------------------
 '
-Private Sub Class_Terminate()
-
-    ' Ignore any errors if object references are no longer valid
-    On Error Resume Next
-    
-    #If APPLICATION_NAME = "Microsoft Access" Then
-        ' Hide front controls
-        mlblFront.Visible = False
-        mlblCaption.Visible = False
-    #Else
-        ' Remove front controls
-        mobjParent.Controls.Remove (mlblFront.Name)
-        mobjParent.Controls.Remove (mlblCaption.Name)
-    #End If
-    Err.Clear ' Clear the Errors if thrown; they're not useful
-End Sub
-
-
+Public Property Get Max() As Double
+    Max = m_Max
+End Property
+Public Property Let Max(NewVal As Double)
+    m_Max = NewVal
+    Update
+End Property
 '---------------------------------------------------------------------------------------
 ' Procedure : Value
 ' Author    : Adam Waller
@@ -149,9 +146,8 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Property Get Value() As Double
-    Value = mdblVal
+    Value = this.dblValue
 End Property
-
 
 '---------------------------------------------------------------------------------------
 ' Procedure : Value
@@ -161,115 +157,45 @@ End Property
 '           : updating screen as needed.
 '---------------------------------------------------------------------------------------
 '
-Public Property Let Value(ByVal dblVal As Double)
+Public Property Let Value(ByVal dblValue As Double)
 
     Dim dblChange As Double
     
     ' Check visibility
-    If Me.Max = 0 Or dblVal = 0 Then
-        mlblFront.Visible = False
-        mlblCaption.Visible = False
+    If Me.Max = 0 Or dblValue = 0 Then
+        this.lblFront.Visible = False
+        this.lblCaption.Visible = False
     Else
         ' Ensure controls are visible
-        If Not mlblBack.Visible Then mlblBack.Visible = True
-        If Not mlblFront.Visible Then mlblFront.Visible = True
-        If Not mblnHideCap And Not mlblCaption.Visible Then mlblCaption.Visible = True
+        If Not this.lblBack.Visible Then this.lblBack.Visible = True
+        If Not this.lblFront.Visible Then this.lblFront.Visible = True
+        If Not this.blnHideCaption And Not this.lblCaption.Visible Then this.lblCaption.Visible = True
     End If
     
     ' Don't allow value to exceed maximum value
-    If dblVal > Me.Max Then dblVal = Me.Max
+    If dblValue > Me.Max Then
+        this.dblValue = Me.Max
+'    ElseIf Me.Max = 0 Then
+'        this.dblValue = 0
+    Else
+        ' Update value
+        this.dblValue = dblValue
+    End If
     
-    ' Measure change
-    dblChange = Abs(dblVal - mdblVal)
+    ' Record start time on first change
+    If this.dteStartTime = 0 Then this.dteStartTime = Now
+    
+    ' Measure change from currently displayed value
+    dblChange = Abs(this.dblValue - this.dblDisplayed)
     
     ' Set value and update display if needed.
     If dblChange > 0 And Me.Max > 0 Then
         ' See if we need to update the display
         ' (Normally updated every 1% or each increment if Smooth = True
-        If Me.Smooth Or ((dblChange / Me.Max) > 0.01) Then
-            mdblVal = dblVal
-            Update
-        End If
+        If Me.Smooth Or ((dblChange / Me.Max) > 0.01) Then Update
     End If
 
 End Property
-
-
-'---------------------------------------------------------------------------------------
-' Procedure : IncrementSize
-' Author    : Adam Waller
-' Date      : 2/17/2021
-' Purpose   : Can use a custom increment size if other than 1.
-'---------------------------------------------------------------------------------------
-'
-Public Property Get IncrementSize() As Double
-    IncrementSize = mdblIncSize
-End Property
-Public Property Let IncrementSize(ByVal dblSize As Double)
-    mdblIncSize = dblSize
-End Property
-
-Public Property Get Max() As Double
-    Max = m_Max
-End Property
-Public Property Let Max(NewVal As Double)
-    m_Max = NewVal
-    Update
-End Property
-
-'---------------------------------------------------------------------------------------
-' Procedure : HideCaption
-' Author    : Adam Waller
-' Date      : 2/17/2021
-' Purpose   : Optionally hide the caption display
-'---------------------------------------------------------------------------------------
-'
-Public Property Get HideCaption() As Boolean
-    HideCaption = mblnHideCap
-End Property
-
-Public Property Let HideCaption(ByVal blnHide As Boolean)
-    mblnHideCap = blnHide
-End Property
-
-
-'---------------------------------------------------------------------------------------
-' Procedure : Update
-' Author    : Adam Waller
-' Date      : 2/17/2021
-' Purpose   : Update the display
-'---------------------------------------------------------------------------------------
-'
-Private Sub Update()
-
-    Dim intPercent As Integer
-    Dim dblWidth As Double
-    
-    ' Set size and caption
-    intPercent = mdblVal * (100 / Me.Max)
-    dblWidth = mdblVal * (mdblFullWidth / Me.Max)
-    mlblFront.Width = dblWidth
-    mlblCaption.Caption = intPercent & "%"
-    
-    ' Use white or black, depending on progress
-    If Me.Value > (Me.Max / 2) Then
-        mlblCaption.ForeColor = 16777215   ' white
-    Else
-        mlblCaption.ForeColor = 0  ' black
-    End If
-
-    ' Use DoEvents to repaint display
-    If mblnNotSmooth Then
-        If mdteLastUpdate <> Now Then
-            ' Update every second
-            DoEvents
-            mdteLastUpdate = Now
-        End If
-    Else
-        DoEvents
-    End If
-
-End Sub
 
 
 '---------------------------------------------------------------------------------------
@@ -301,6 +227,59 @@ End Sub
 
 
 '---------------------------------------------------------------------------------------
+' Procedure : EstCompletionTime
+' Author    : Adam Waller
+' Date      : 4/21/2022
+' Purpose   : Return an estimated completion time based on the start date and remaining
+'           : segments. (Simple calculation assuming even increment intervals.)
+'---------------------------------------------------------------------------------------
+'
+Public Property Get EstCompletionTime() As Date
+
+    Dim dblSeconds As Double
+    Dim dblRemaining As Double
+    
+    If this.dteStartTime = 0 Then
+        EstCompletionTime = Now
+    Else
+        With this
+            ' Get elapsed seconds
+            dblSeconds = DateDiff("s", .dteStartTime, Now)
+            ' Calculate remaining seconds
+            dblRemaining = (dblSeconds / .dblValue) * (Me.Max - .dblValue)
+            ' Convert to completion time
+            EstCompletionTime = DateAdd("s", dblRemaining, Now)
+        End With
+    End If
+    
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : EstRemainingTime
+' Author    : Adam Waller
+' Date      : 4/21/2022
+' Purpose   : Return a string value with the estimated hours/minutes/seconds remaining.
+'           : Example return values: "73 seconds", "41 minutes", "80 hours"
+'---------------------------------------------------------------------------------------
+'
+Public Property Get EstRemainingTime() As String
+
+    Dim dblSeconds As Double
+    
+    dblSeconds = DateDiff("s", Now, Me.EstCompletionTime)
+    If dblSeconds < 120 Then
+        EstRemainingTime = dblSeconds & " seconds"
+    ElseIf dblSeconds < (60 * 120) Then
+        EstRemainingTime = dblSeconds \ 60 & " minutes"
+    Else
+        EstRemainingTime = dblSeconds \ 3600 & " hours"
+    End If
+    
+End Property
+
+
+'---------------------------------------------------------------------------------------
 ' Procedure : Clear
 ' Author    : Adam Waller
 ' Date      : 2/17/2021
@@ -321,7 +300,8 @@ End Sub
 '
 Public Sub Reset()
     Me.Value = 0
-    Update
+    this.dteStartTime = 0
+    Update True
 End Sub
 
 
@@ -334,8 +314,111 @@ End Sub
 '
 Public Sub Hide()
     On Error Resume Next
-    mlblCaption.Visible = False
-    mlblFront.Visible = False
-    mlblBack.Visible = False
-    CatchAny eelNoError, vbNullString, vbNullString, False, True
+    With this
+        .lblCaption.Visible = False
+        .lblFront.Visible = False
+        .lblBack.Visible = False
+    End With
+    Err.Clear
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Update
+' Author    : Adam Waller
+' Date      : 2/17/2021
+' Purpose   : Update the display
+'---------------------------------------------------------------------------------------
+'
+Private Sub Update(Optional ByRef ForceUpdate As Boolean = False)
+
+    Dim intPercent As Integer
+    Dim dblWidth As Double
+    Static dteLastUpdate As Date
+
+    ' Set size and caption
+    With this
+        If Me.Max = 0 Or .dblValue = 0 Then
+            .lblFront.Visible = False
+            .lblCaption.Visible = False
+            intPercent = 0
+            dblWidth = 0
+        Else
+            intPercent = .dblValue * (100 / Me.Max)
+            dblWidth = .dblValue * (.dblFullWidth / Me.Max)
+        End If
+        .lblFront.Width = dblWidth
+        .lblCaption.Caption = intPercent & "%"
+        .dblDisplayed = .dblValue
+    End With
+    
+    ' Use white or black, depending on progress level
+    If Me.Value > (Me.Max / 2) Then
+        ' Show white on blue background after 50%
+        this.lblCaption.ForeColor = 16777215
+    Else
+        ' Show black on grey background
+        this.lblCaption.ForeColor = 0
+    End If
+
+    ' Use DoEvents to repaint display
+    If Me.Smooth Then
+        ' Always update display
+        DoEvents
+    ElseIf (dteLastUpdate <> Now) Or ForceUpdate Then
+        ' Update every second
+        DoEvents
+        dteLastUpdate = Now
+    End If
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetParentFormName
+' Author    : Adam Waller
+' Date      : 2/17/2021
+' Purpose   : Return the name of the parent form
+'---------------------------------------------------------------------------------------
+'
+Private Function GetParentFormName(ctlControl As Control) As String
+
+    ' returns the name of the parent form
+    Dim objParent As Object
+    
+    Set objParent = ctlControl
+    
+    Do While Not TypeOf objParent Is Form
+       Set objParent = objParent.Parent
+    Loop
+    
+    ' Now we should have the parent form
+    GetParentFormName = objParent.Name
+    
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Class_Terminate
+' Author    : Adam Waller
+' Date      : 2/17/2021
+' Purpose   : Remove temporary controls, if applicable
+'---------------------------------------------------------------------------------------
+'
+Private Sub Class_Terminate()
+    Me.Reset
+    Me.Hide
+    ' Ignore any errors if object references are no longer valid
+    On Error Resume Next
+    #If APPLICATION_NAME = "Microsoft Access" Then
+        ' Hide front controls
+        this.lblFront.Visible = False
+        this.lblCaption.Visible = False
+    #Else
+        ' Remove front controls
+        this.objParent.Controls.Remove (mlblFront.Name)
+        this.objParent.Controls.Remove (mlblCaption.Name)
+    #End If
+    Err.Clear ' Clear any errors, they mean the form closed before the class terminated.
+
 End Sub

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -244,8 +244,11 @@ Public Sub Increment(Optional dblAmount As Double = 1)
     Dim dblNew As Double
     
     ' Calculate how much to add
-    If dblAmount = 1 And Me.IncrementSize > 0 Then dblAdd = Me.IncrementSize
-    If dblAdd = 0 Then dblAdd = dblAmount
+    If dblAmount = 1 Then
+        dblAdd = Me.IncrementSize
+    Else
+        dblAdd = dblAmount
+    End If
     
     ' Check boundaries
     dblNew = Me.Value + dblAdd
@@ -370,7 +373,7 @@ Private Sub Update(Optional ByRef ForceUpdate As Boolean = False)
 
     ' Set size and caption
     With this
-        If Me.Max = 0 Or .dblValue = 0 Then
+        If Me.Max = 0 Then
             .lblFront.Visible = False
             .lblCaption.Visible = False
             intPercent = 0

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -37,7 +37,7 @@ Option Compare Database
 
 
 ' Public properties
-Public Max As Double                    ' Maximum value of progress bar at 100%
+Private m_Max As Double                    ' Maximum value of progress bar at 100%
 Public Smooth As Boolean                ' Set to true for smooth updates < 1%
 
 ' Private properties
@@ -57,7 +57,7 @@ Private mblnNotSmooth As Boolean        ' Display smoothly by doevents after eve
 ' Purpose   : Initialize the progress bar before using it
 '---------------------------------------------------------------------------------------
 '
-Public Sub Initialize(BackLabel As Label, Optional FrontLabel As Label, Optional CaptionLabel As Label)
+Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef CaptionLabel As Label)
 
     Dim objParent As Object ' could be a form or tab control
     Dim frm As Form
@@ -92,7 +92,7 @@ Public Sub Initialize(BackLabel As Label, Optional FrontLabel As Label, Optional
         .Top = mlblBack.Top + sngOffset
         .Width = 0
         .Height = mlblBack.Height - (sngOffset * 2)
-        .Caption = ""
+        .Caption = vbNullString
         .BackColor = 8388608
         .BackStyle = 1
         .Visible = True
@@ -105,12 +105,14 @@ Public Sub Initialize(BackLabel As Label, Optional FrontLabel As Label, Optional
         .Width = mlblBack.Width - 4
         .Height = mlblBack.Height - 4
         .TextAlign = 2 'fmTextAlignCenter
+        .TopMargin = sngOffset * 2
         .BackStyle = 0 'fmBackStyleTransparent
         .Caption = "0%"
         .Visible = Not Me.HideCaption
         .ForeColor = 16777215   ' white
     End With
-
+    If Me.Max = 0 Then Me.Max = 100
+    Update
 End Sub
 
 
@@ -135,7 +137,7 @@ Private Sub Class_Terminate()
         mobjParent.Controls.Remove (mlblFront.Name)
         mobjParent.Controls.Remove (mlblCaption.Name)
     #End If
-
+    Err.Clear ' Clear the Errors if thrown; they're not useful
 End Sub
 
 
@@ -207,6 +209,13 @@ Public Property Let IncrementSize(ByVal dblSize As Double)
     mdblIncSize = dblSize
 End Property
 
+Public Property Get Max() As Double
+    Max = m_Max
+End Property
+Public Property Let Max(NewVal As Double)
+    m_Max = NewVal
+    Update
+End Property
 
 '---------------------------------------------------------------------------------------
 ' Procedure : HideCaption
@@ -299,7 +308,7 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub Clear()
-    Call Class_Terminate
+    Class_Terminate
 End Sub
 
 
@@ -312,6 +321,7 @@ End Sub
 '
 Public Sub Reset()
     Me.Value = 0
+    Update
 End Sub
 
 
@@ -323,31 +333,9 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub Hide()
+    On Error Resume Next
     mlblCaption.Visible = False
     mlblFront.Visible = False
     mlblBack.Visible = False
+    CatchAny eelNoError, vbNullString, vbNullString, False, True
 End Sub
-
-
-'---------------------------------------------------------------------------------------
-' Procedure : GetParentFormName
-' Author    : Adam Waller
-' Date      : 2/17/2021
-' Purpose   : Return the name of the parent form
-'---------------------------------------------------------------------------------------
-'
-Private Function GetParentFormName(ctlControl As Control) As String
-
-    ' returns the name of the parent form
-    Dim objParent As Object
-    
-    Set objParent = ctlControl
-    
-    Do While Not TypeOf objParent Is Form
-       Set objParent = objParent.Parent
-    Loop
-    
-    ' Now we should have the parent form
-    GetParentFormName = objParent.Name
-    
-End Function

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -21,7 +21,7 @@ Option Compare Database
 ' object types in early binding.
 #Const APPLICATION_NAME = "Microsoft Access"
 
-Const CompletionFormat As String = "0.00" ' Defines the number of digits to display.
+Private Const CompletionFormat As String = "0.00" ' Defines the number of digits to display.
 
 ' Public properties
 Private m_Max As Double                 ' Maximum value of progress bar at 100%

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -21,8 +21,10 @@ Option Compare Database
 ' object types in early binding.
 #Const APPLICATION_NAME = "Microsoft Access"
 
+Const CompletionFormat As String = "0.00" ' Defines the number of digits to display.
+
 ' Public properties
-Private m_Max As Double                    ' Maximum value of progress bar at 100%
+Private m_Max As Double                  ' Maximum value of progress bar at 100%
 Public Smooth As Boolean                ' Set to true for smooth updates < 1%
 Public IncrementSize                    ' Custom size of increments
 Public HideCaption                      ' Optionally hide the percentage label
@@ -52,6 +54,9 @@ Private Type udtProg
     blnHideCaption As Boolean           ' Show/hide percent complete caption
     objParent As Object                 ' Parent object of back label
     dteStartTime As Date                ' Time of first value change
+    blnShowTimeRemain As Boolean        ' Show time on progress bar in addition to Percentage
+    blnShowTimeComplete As Boolean      ' Show time of completion (clock time) in addition to percentage.
+                                        ' Only Time remaining OR clock time can be shown; if you turn on one the other will turn off.
 End Type
 Private this As udtProg
 
@@ -122,6 +127,22 @@ Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef
     Update
 
 End Sub
+
+
+Public Property Get DisplayTimeRemaining() As Boolean
+    DisplayTimeRemaining = this.blnShowTimeRemain
+End Property
+Public Property Let DisplayTimeRemaining(NewVal As Boolean)
+    this.blnShowTimeRemain = NewVal
+    If NewVal Then this.blnShowTimeComplete = False
+End Property
+Public Property Get DisplayTimeComplete() As Boolean
+    DisplayTimeComplete = this.blnShowTimeComplete
+End Property
+Public Property Let DisplayTimeComplete(NewVal As Boolean)
+    this.blnShowTimeComplete = NewVal
+    If NewVal Then this.blnShowTimeRemain = False
+End Property
 
 
 '---------------------------------------------------------------------------------------
@@ -246,7 +267,7 @@ Public Property Get EstCompletionTime() As Date
             ' Get elapsed seconds
             dblSeconds = DateDiff("s", .dteStartTime, Now)
             ' Calculate remaining seconds
-            dblRemaining = (dblSeconds / .dblValue) * (Me.Max - .dblValue)
+            If .dblValue > 0 Then dblRemaining = (dblSeconds / .dblValue) * (Me.Max - .dblValue)
             ' Convert to completion time
             EstCompletionTime = DateAdd("s", dblRemaining, Now)
         End With
@@ -269,11 +290,11 @@ Public Property Get EstRemainingTime() As String
     
     dblSeconds = DateDiff("s", Now, Me.EstCompletionTime)
     If dblSeconds < 120 Then
-        EstRemainingTime = dblSeconds & " seconds"
+        EstRemainingTime = Format(dblSeconds, CompletionFormat) & " seconds"
     ElseIf dblSeconds < (60 * 120) Then
-        EstRemainingTime = dblSeconds \ 60 & " minutes"
+        EstRemainingTime = Format(dblSeconds / 60, CompletionFormat) & " minutes"
     Else
-        EstRemainingTime = dblSeconds \ 3600 & " hours"
+        EstRemainingTime = Format(dblSeconds / 3600, CompletionFormat) & " hours"
     End If
     
 End Property
@@ -348,7 +369,15 @@ Private Sub Update(Optional ByRef ForceUpdate As Boolean = False)
             dblWidth = .dblValue * (.dblFullWidth / Me.Max)
         End If
         .lblFront.Width = dblWidth
-        .lblCaption.Caption = intPercent & "%"
+        
+        If .blnShowTimeComplete Then
+            .lblCaption.Caption = intPercent & "% Est. Completion Time: " & Me.EstCompletionTime
+        ElseIf .blnShowTimeRemain Then
+            .lblCaption.Caption = intPercent & "% Est. Remaining Time: " & Me.EstRemainingTime
+        Else
+            .lblCaption.Caption = intPercent & "%"
+        End If
+
         .dblDisplayed = .dblValue
     End With
     

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -67,9 +67,6 @@ Private this As udtProg
 '---------------------------------------------------------------------------------------
 '
 Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef CaptionLabel As Label)
-
-    Dim objParent As Object ' could be a form or tab control
-    Dim frm As Form
     
     Set this.objParent = BackLabel.Parent
     Set this.lblBack = BackLabel

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -136,7 +136,7 @@ Public Property Get Max() As Double
 End Property
 Public Property Let Max(NewVal As Double)
     m_Max = NewVal
-    Update
+    Update True
 End Property
 '---------------------------------------------------------------------------------------
 ' Procedure : Value

--- a/Version Control.accda.src/modules/clsLblProg.cls
+++ b/Version Control.accda.src/modules/clsLblProg.cls
@@ -24,10 +24,8 @@ Option Compare Database
 Const CompletionFormat As String = "0.00" ' Defines the number of digits to display.
 
 ' Public properties
-Private m_Max As Double                  ' Maximum value of progress bar at 100%
+Private m_Max As Double                 ' Maximum value of progress bar at 100%
 Public Smooth As Boolean                ' Set to true for smooth updates < 1%
-Public IncrementSize                    ' Custom size of increments
-Public HideCaption                      ' Optionally hide the percentage label
 
 ' Private properties
 Private Type udtProg
@@ -121,13 +119,19 @@ Public Sub Initialize(ByRef BackLabel As Label, ByRef FrontLabel As Label, ByRef
         .TopMargin = this.sngOffset * 2
         .BackStyle = 0 'fmBackStyleTransparent
         .Caption = "0%"
-        .Visible = Not Me.HideCaption
+        .Visible = Not this.blnHideCaption
         .ForeColor = 16777215   ' white
     End With
     Update
 
 End Sub
 
+Public Property Get HideCaption() As Boolean
+    HideCaption = this.blnHideCaption
+End Property
+Public Property Let HideCaption(NewVal As Boolean)
+    this.blnHideCaption = NewVal
+End Property
 
 Public Property Get DisplayTimeRemaining() As Boolean
     DisplayTimeRemaining = this.blnShowTimeRemain
@@ -218,6 +222,13 @@ Public Property Let Value(ByVal dblValue As Double)
 
 End Property
 
+Public Property Get IncrementSize() As Double
+    If this.dblIncrementSize <= 0 Then this.dblIncrementSize = 1
+    IncrementSize = this.dblIncrementSize
+End Property
+Public Property Let IncrementSize(NewVal As Double)
+    this.dblIncrementSize = NewVal
+End Property
 
 '---------------------------------------------------------------------------------------
 ' Procedure : Increment

--- a/Version Control.accda.src/modules/clsLog.cls
+++ b/Version Control.accda.src/modules/clsLog.cls
@@ -322,31 +322,12 @@ End Sub
 '---------------------------------------------------------------------------------------
 '
 Public Sub Increment()
-    
-    ' Track the last time we did an increment
-    Static sngLastIncrement As Single
-    Static lngProgress As Long
-    
+
     ' Ignore if we are not using the form
     If m_Prog Is Nothing Then Exit Sub
-    
-    ' Increment value, even if we don't display it.
-    lngProgress = lngProgress + 1
-    
-    ' Don't run the incrementer unless it has been 1
-    ' second since the last displayed output refresh.
-    If m_sngLastUpdate > Timer - 1 Then Exit Sub
-    
-    ' Allow an update to the screen every x seconds.
-    ' Find the balance between good progress feedback
-    ' without slowing down the overall export time.
-    If sngLastIncrement > Timer - 0.5 Then Exit Sub
-
     ' Check the current status.
     Perf.OperationStart "Increment Progress"
     If Not m_blnProgressActive Then
-        ' Show the progress bar
-        lngProgress = 1
         ' Flush any pending output
         With m_RichText
             Echo False
@@ -358,12 +339,9 @@ Public Sub Increment()
             Echo True
         End With
     End If
-    
-    ' Status is now active
-    sngLastIncrement = Timer
-    m_blnProgressActive = True
-    m_Prog.Value = lngProgress
-    Perf.OperationEnd
-    
-End Sub
+    Me.ProgressBar.Increment
 
+    ' Status is now active
+    m_blnProgressActive = True
+    Perf.OperationEnd
+End Sub


### PR DESCRIPTION
Fix bug in `clsLblProg` throws errors if you close the form before terminating the class.
Also added in patch to remove unused function `GetParentFormName`.