### PR TITLE
Type Mismatch Fix & Non-returning Function Fix

### DIFF
--- a/Version Control.accda.src/modules/clsDbSharedImage.cls
+++ b/Version Control.accda.src/modules/clsDbSharedImage.cls
@@ -211,6 +211,7 @@ Private Function LoadItem(strName As String) As Boolean
             Loop
             .Close
         End With
+        LoadItem = True
     End If
 
 End Function

--- a/Version Control.accda.src/modules/clsDbTableDef.cls
+++ b/Version Control.accda.src/modules/clsDbTableDef.cls
@@ -467,6 +467,7 @@ Private Function ImportLinkedTable(strFile As String) As Boolean
                     dbs.TableDefs.Refresh
                 End If
             End If
+            ImportLinkedTable = (Err.Number = 0)
         End If
     End If
     

--- a/Version Control.accda.src/modules/clsVCSIndex.cls
+++ b/Version Control.accda.src/modules/clsVCSIndex.cls
@@ -383,7 +383,7 @@ End Function
 '
 Public Function GetModifiedSourceFiles(cCategory As IDbComponent) As Collection
 
-    Dim colAllFiles As Collection
+    Dim colAllFiles As Dictionary
     Dim varFile As Variant
     Dim strFile As String
     Dim strPath As String

--- a/Version Control.accda.src/modules/modOrphaned.bas
+++ b/Version Control.accda.src/modules/modOrphaned.bas
@@ -27,8 +27,8 @@ Public Sub ClearOrphanedSourceFolders(cType As IDbComponent)
     Dim varKey As Variant
     Dim colNames As Collection
     Dim cItem As IDbComponent
-    Dim oFolder As Folder
-    Dim oSubFolder As Folder
+    Dim oFolder As Scripting.Folder
+    Dim oSubFolder As Scripting.Folder
     Dim strSubFolderName As String
     
     ' No orphaned files if the folder doesn't exist.
@@ -79,8 +79,8 @@ End Sub
 '
 Public Sub ClearOrphanedSourceFiles(cType As IDbComponent, ParamArray StrExtensions())
     
-    Dim oFolder As Folder
-    Dim oFile As File
+    Dim oFolder As Scripting.Folder
+    Dim oFile As Scripting.File
     Dim dBaseNames As Dictionary
     Dim dExtensions As Dictionary
     Dim strBaseName As String

--- a/Version Control.accda.src/modules/modSanitize.bas
+++ b/Version Control.accda.src/modules/modSanitize.bas
@@ -701,7 +701,7 @@ Private Function FormatXML(strSourceXML As String, _
     ' Trap any errors with parsing or formatting the XML
     If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
     
-    Set objWriter = New MXHTMLWriter60
+    Set objWriter = New MXXMLWriter60
     Set objReader = New SAXXMLReader60
     
     ' Set up writer

--- a/Version Control.accda.src/modules/modVbeForm.bas
+++ b/Version Control.accda.src/modules/modVbeForm.bas
@@ -79,7 +79,7 @@ Private Function IsSerializableProperty(ByVal Context As Object, ByVal Property 
     End If
 End Function
 
-Private Function GetProperty(ByVal Context As Object, ByVal Property As Property) As Dictionary
+Private Function GetProperty(ByVal Context As Object, ByVal Property As VBIDE.Property) As Dictionary
     Dim dict As New Dictionary
     dict.Add "Name", Property.Name
     If Property.Name = "Controls" Then


### PR DESCRIPTION
Fixed type mismatch bugs:
-  modSanitize_FormatXML 'objWriter' variable was declared as 'MXXMLWriter60' and set as 'MXHTMLWriter60'.
-  modOrphaned had multiple variables declared with the 'Folder' type and set as 'Scripting.Folder'.  This could conflict with the 'IWshRuntimeLibrary.Folder' type.
-  modVBEForm had a missing 'VBIDE' qualifier before a 'Property' type declaration.
-  clsVCSIndex 'colAllFiles' was declared as a 'VBA.Collection' and set as a 'Scripting.Dictionary'.  

 Fixed two functions with non-returning values:
- clsDbTableDef_ImportLinkedTable always returned 'false' resulting in the index never updating for linked table json files in 'IDbComponent_Import'
- clsDbSharedImage_LoadItem always returned 'false'.  (Same problem as above).