### PR TITLE
Improved blob support & connection string handling

### DIFF
--- a/Version Control.accda.src/db-connection.json
+++ b/Version Control.accda.src/db-connection.json
@@ -1,0 +1,8 @@
+﻿{
+  "Info": {
+    "Class": "clsDbConnection",
+    "Description": "Database connections used within the project used to prime Access' internal cache during import."
+  },
+  "Items": {
+  }
+}

--- a/Version Control.accda.src/dbs-properties.json
+++ b/Version Control.accda.src/dbs-properties.json
@@ -41,7 +41,7 @@
       "Type": 10
     },
     "AppVersion": {
-      "Value": "4.0.9",
+      "Value": "4.1.0",
       "Type": 10
     },
     "Auto Compact": {

--- a/Version Control.accda.src/modules/clsConnectionODBC.cls
+++ b/Version Control.accda.src/modules/clsConnectionODBC.cls
@@ -1,0 +1,426 @@
+﻿VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsConnectionODBC"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+'---------------------------------------------------------------------------------------
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : This class provides the parsing of ODBC connection string into key-value
+'           : pairs, conforming to the grammar defined by MS-ODBCSTR open specification.
+'           : This class can be also used to aid in comparing whether 2 ODBC connection
+'           : strings are considered equivalent by Access via the property named
+'           : `SanitizedConnectionString`.
+'           :
+'           : For the complete speccification of MS-ODBCSTR, see:
+'           : https://learn.microsoft.com/en-us/openspecs/sql_server_protocols/ms-odbcstr/13b4e848-b36c-4b11-acce-d6bf199d5391
+'---------------------------------------------------------------------------------------
+Option Compare Database
+Option Explicit
+
+Private Type typData
+    ' 2.2 Generic keys
+    Driver As String
+    DSN As String
+    FileDSN As String
+    UID As String
+    PWD As String
+    SaveFile As String
+    
+    ' Those technically are not generic keys but they are very
+    ' common among a variety of ODBC drivers and Access do treat
+    ' two connection strings with a different values for those
+    ' keys differently.
+    Server As String
+    Port As String ' Should be either an integer between 0 to 65535 or empty
+    Database As String
+    
+    ' The rest of members below are for class' use and is not related to
+    ' the ODBC connection string specifications.
+    OriginalConnectionString As String
+    SanitizedConnectionString As String
+    
+    KeyValues As Scripting.Dictionary
+End Type
+Private This As typData
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Driver
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the driver key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get Driver() As String
+    Driver = This.Driver
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : DSN
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the DSN key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get DSN() As String
+    DSN = This.DSN
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : FileDSN
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the FileDSN key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get FileDSN() As String
+    FileDSN = This.FileDSN
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : UID
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the UID key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get UID() As String
+    UID = This.UID
+End Property
+    
+
+'---------------------------------------------------------------------------------------
+' Procedure : PWD
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the PWD key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get PWD() As String
+    PWD = This.PWD
+End Property
+    
+
+'---------------------------------------------------------------------------------------
+' Procedure : SaveFile
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the SaveFile key in the connection string if present.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get SaveFile() As String
+    SaveFile = This.SaveFile
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Server
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the Server key in the connection string if present.
+'           : This is not a generic key but Access does uses it for comparison.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get Server() As String
+    Server = This.Server
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Port
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the Port key in the connection string if present.
+'           : This is not a generic key but Access does uses it for comparison.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get Port() As String
+    Port = This.Port
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Database
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the value for the Database key in the connection string if present.
+'           : This is not a generic key but Access does uses it for comparison.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get Database() As String
+    Database = This.Database
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : OriginalConnectionString
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the original connection string that was used in the call to
+'           : ParseOdbcConnectionString.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get OriginalConnectionString() As String
+    OriginalConnectionString = This.OriginalConnectionString
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : SanitizedConnectionString
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns the sanitized connection string that was returned from the call to
+'           : ParseOdbcConnectionString. This is useful for comparing with other
+'           : connection strings to determine if they are equivalent.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get SanitizedConnectionString() As String
+    SanitizedConnectionString = This.SanitizedConnectionString
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetKeyValues
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Returns a dictionary of key/values. If a key is non-generic and has
+'           : multiple values, the value are split with vbNullChar character. The
+'           : generic key retains only the last value.
+'---------------------------------------------------------------------------------------
+'
+Public Function GetKeyValues() As Scripting.Dictionary
+    Set GetKeyValues = New Scripting.Dictionary
+    GetKeyValues.CompareMode = TextCompare
+    
+    Dim varKey As Variant
+    For Each varKey In This.KeyValues
+        GetKeyValues.Add varKey, This.KeyValues(varKey)
+    Next
+End Function
+
+Public Sub ParseOdbcConnectionString(strConnect As String)
+    If StartsWith(strConnect, "ODBC;", vbTextCompare) = False Then
+        Exit Sub
+    End If
+    
+    ResetData
+    
+    ' 2.1.1 Common ABNF Rules
+    ' SC           = %x3B         ; Semicolon
+    ' LCB          = %x7B         ; Left curly brackets
+    ' RCB          = %x7D         ; Right curly brackets
+    ' EQ           = %x3D         ; Equal sign
+    ' ESCAPEDRCB   = 2RCB         ; Double right curly brackets
+    ' SpaceStr     = *(SP)        ; Any number of spaces (including 0 spaces)
+
+    ' 2.1.2 ODBC Connection String Format
+    ' ODBCConnectionString =  *(KeyValuePair SC) KeyValuePair [SC]
+    ' KeyValuePair = (Key EQ Value / SpaceStr)
+    ' Key = SpaceStr KeyName
+    ' KeyName = (nonSP-SC-EQ *nonEQ)
+    ' Value = (SpaceStr ValueFormat1 SpaceStr) / (ValueContent2)
+    ' ValueFormat1 = LCB ValueContent1 RCB
+    ' ValueContent1 = *(nonRCB / ESCAPEDRCB)
+    ' ValueContent2 = SpaceStr / SpaceStr (nonSP-LCB-SC) *nonSC
+    ' nonRCB = %x01-7C / %x7E-FFFF                                 ; not "}"
+    ' nonSP-LCB-SC = %x01-1F / %x21-3A / %x3C-7A / %x7C-FFFF       ; not space, "{" or ";"
+    ' nonSP-SC-EQ = %x01-1F / %x21-3A / %x3C / %x3E-FFFF           ; not space, ";" or "="
+    ' nonEQ = %x01-3C / %x3E-FFFF                                  ; not "="
+    ' nonSC = %x01-003A / %x3C-FFFF                                ; not ";"
+    
+    ' Use https://regex101.com/ to provide a detailed explanation of the pattern
+    ' It should conform to the rules defined by the MS-ODBCSTR and extract the
+    ' key as the first match and the value as either 2nd or 3rd match. The 2nd
+    ' match represents the ValueFormat1 specification and 3rd match, the
+    ' ValueContent2 specification.
+    Const RegExpPattern As String = "\s?([^ ;=][^=]*?)=(?:\s?(\{(?:[^}]|\}\})*?\})\s?|\s?([^ ;{][^;]*)|\s?)(?:;|$)"
+    
+    Dim objRegExp As VBScript_RegExp_55.RegExp
+    Dim objMatches As VBScript_RegExp_55.MatchCollection
+    Dim objMatch As VBScript_RegExp_55.Match
+    Dim strKey As String
+    Dim strValue As String
+    
+    Set objRegExp = New VBScript_RegExp_55.RegExp
+    With objRegExp
+        .Global = True
+        .IgnoreCase = True
+        .Multiline = True
+        .Pattern = RegExpPattern
+        ' Test only the substring without the `ODBC;` prefix which technically is not
+        ' a part of the ODBC connection string but rather a protocol specifier used by
+        ' Access itself.
+        Set objMatches = .Execute(Mid$(strConnect, 6))
+    End With
+    
+    This.OriginalConnectionString = strConnect
+    Set This.KeyValues = New Scripting.Dictionary
+    This.KeyValues.CompareMode = TextCompare
+    
+    For Each objMatch In objMatches
+        With objMatch
+            strKey = .SubMatches(0)
+            If Len(.SubMatches(1)) Then
+                strValue = .SubMatches(1) ' ValueFormat1
+            ElseIf Len(.SubMatches(2)) Then
+                strValue = .SubMatches(2) ' ValueContent2
+            Else
+                strValue = vbNullString ' No matches; assume empty string
+            End If
+            
+            If This.KeyValues.Exists(strKey) Then
+                ' 2.2.3 indicates generic key takes the last value. Driver specific
+                ' key however is driver-defined. We'll use vbNullChar as delimiter
+                ' to support weird oddball drivers that likes having multiple values.
+                '
+                ' NOTE: according to 3.10, SQL Server drivers will take the first value
+                ' and ignore subsequent values.
+                If IsGenericKey(strKey) Then
+                    This.KeyValues(strKey) = strValue
+                Else
+                    This.KeyValues(strKey) = This.KeyValues(strKey) & vbNullChar & strValue
+                End If
+            Else
+                This.KeyValues.Add strKey, strValue
+            End If
+            
+            Select Case strKey
+                Case "Driver"
+                    This.Driver = strValue
+                Case "DSN"
+                    This.DSN = strValue
+                Case "FileDSN"
+                    This.FileDSN = strValue
+                Case "SaveFile"
+                    This.SaveFile = strValue
+                Case "UID"
+                    This.UID = strValue
+                Case "PWD"
+                    This.PWD = strValue
+                    
+                ' The following keys are non-generic so take the first value
+                ' for the purpose of sanitized connection string comparison
+                Case "Server"
+                    If Len(This.Server) = 0 Then
+                        This.Server = strValue
+                    End If
+                Case "Database"
+                    If Len(This.Database) = 0 Then
+                        This.Database = strValue
+                    End If
+                Case "Port"
+                    If Len(This.Port) = 0 Then
+                        This.Port = strValue
+                    End If
+            End Select
+        End With
+    Next
+    
+    ' Build the sanitized connection string based on key parameters that Access will use
+    ' to differeniate one connection string from another. This is based on experience
+    ' because there is no formal documentation for how Access treats one connection string.
+    ' WizHook provides IsMatchToDbcConnectString but that does not seem to suit our needs.
+    ' What is known:
+    '   Access pays attention to the following keywords: Driver, Server, Database and Port
+    '   Access does not consider UID or PWD
+    '   Other keys are ignored.
+    '   Order of keys appearing in the connection string seems to have a factor.
+    '
+    ' As a matter of best practice, it's best that we avoid having multiple variants of
+    ' essentially same connection string and user probably should consider multiple
+    ' occurrences of same connection strings differently formatted as a potential problem
+    ' to be fixed to avoid runtime problems such as Access prompting for credentials
+    ' in unexpected places. So for this purpose, we will allow multiple variants and leave it
+    ' up to the user to make corrections to their project to minimize the variants.
+    '
+    ' According to 2.3.2 & 3.8, generally the key value pairs in the connection string
+    ' takes precedence so if we find `Driver` key, we always use that, followed by `DSN`
+    ' then finally `FileDSN`. The specification also mentions FileDSN needing to precede
+    ' DSN but we don't handle this.
+    
+    Dim objConcat As clsConcat
+    Set objConcat = New clsConcat
+    
+    If Len(This.Driver) Then
+        objConcat.Add ";Driver=", This.Driver
+    ElseIf Len(This.DSN) Then
+        objConcat.Add ";DSN=", This.DSN
+    ElseIf Len(This.FileDSN) Then
+        objConcat.Add ";FileDSN=", This.FileDSN
+    Else
+        ' Apparently this is an incomplete ODBC connection string. Access would always prompt to fill in.... Masochistic?
+    End If
+    
+    If Len(This.SaveFile) Then
+        objConcat.Add ";SaveFile=", This.SaveFile
+    End If
+    
+    If Len(This.Server) Then
+        objConcat.Add ";SERVER=", This.Server
+    End If
+    
+    If Len(This.Port) Then
+        objConcat.Add ";PORT=", This.Port
+    End If
+    
+    If Len(This.Database) Then
+        objConcat.Add ";DATABASE=", This.Database
+    End If
+    
+    If Len(This.UID) Then
+        objConcat.Add ";UID=", This.UID
+    End If
+    
+    If Len(This.PWD) Then
+        objConcat.Add ";PWD=", This.PWD
+    End If
+    
+    This.SanitizedConnectionString = "ODBC" & objConcat.GetStr
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : IsGenericKey
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Indicates if a given key name is generic or not, as specified in
+'           : MS-ODBCSTR 2.2 Generic Keys
+'---------------------------------------------------------------------------------------
+'
+Public Function IsGenericKey(strKey As String) As Boolean
+    Select Case strKey
+        Case "Driver", _
+             "DSN", _
+             "FileDSN", _
+             "UID", _
+             "PWD", _
+             "SaveFile"
+            IsGenericKey = True
+    End Select
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ResetData
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : Resets the cached values
+'---------------------------------------------------------------------------------------
+'
+Private Sub ResetData()
+    Dim Blank As typData
+    
+    ' Not necessary but best to ensure proper de-referencing
+    Set This.KeyValues = Nothing
+    
+    LSet This = Blank
+End Sub
+

--- a/Version Control.accda.src/modules/clsDbConnection.cls
+++ b/Version Control.accda.src/modules/clsDbConnection.cls
@@ -1,0 +1,446 @@
+﻿VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "clsDbConnection"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = False
+'---------------------------------------------------------------------------------------
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : This class extends the IDbComponent class to perform the specific
+'           : operations required by this particular object type.
+'           : (I.e. The specific way you export or import this component.)
+'           :
+'           : This class actually doesn't import or export anything but provides
+'           : useful metadata about the connections that the database project has.
+'           : During "export", all possible connections are harvested while "import"
+'           : will prime Access' internal cache, which helps reduce the numbers of
+'           : ODBC login dialogs that may pop open during the imports of associated
+'           : database objects.
+'---------------------------------------------------------------------------------------
+Option Compare Database
+Option Explicit
+
+Private m_dItems As Dictionary
+
+' This requires us to use all the public methods and properties of the implemented class
+' which keeps all the component classes consistent in how they are used in the export
+' and import process. The implemented functions should be kept private as they are called
+' from the implementing class, not this class.
+Implements IDbComponent
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Export
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Export the individual database component (table, form, query, etc...)
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_Export(Optional strAlternatePath As String)
+    Dim strContent As String
+    strContent = GetSource
+    WriteFile strContent, Nz2(strAlternatePath, IDbComponent_SourceFile)
+    VCSIndex.Update Me, IIf(strAlternatePath = vbNullString, eatExport, eatAltExport), GetStringHash(strContent, True)
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Import
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Import the individual database component from a file.
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_Import(strFile As String)
+
+    Dim dConnections As Scripting.Dictionary
+    Dim varConnect As Variant
+
+    If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
+
+    ' Only import files with the correct extension.
+    If Not strFile Like "*.json" Then Exit Sub
+    Set dConnections = ReadJsonFile(strFile).Item("Items")
+    
+    ' Prime Access' internal cache. If the connection string is incomplete, it will
+    ' pop open a dialog from the driver for the user to then fill in.
+    For Each varConnect In dConnections
+        ' We only need to process the sanitized connection strings, rather than possible
+        ' connection strings which help reduce number of logins user may need to
+        ' complete.
+        Dim x As Variant
+        For Each x In dConnections(varConnect)
+            CacheConnection CStr(x)
+        Next
+    Next
+    
+    CatchAny eelError, "Importing Project", ModuleName(Me) & ".Import"
+
+    ' Save to index
+    VCSIndex.Update Me, eatImport, GetDictionaryHash(GetDictionary)
+
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetSource
+' Author    : Adam Waller
+' Date      : 2/14/2022
+' Purpose   : Return the full content that will be saved to the source file.
+'---------------------------------------------------------------------------------------
+'
+Private Function GetSource() As String
+    GetSource = BuildJsonFile(TypeName(Me), GetDictionary, "Database connections used within the project used to prime Access' internal cache during import.")
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetDictionary
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a dictionary object of project connections.
+'---------------------------------------------------------------------------------------
+'
+Private Function GetDictionary(Optional blnUseCache As Boolean = True) As Dictionary
+
+    ' Check cache first
+    If blnUseCache And Not m_dItems Is Nothing Then
+        Set GetDictionary = m_dItems
+        Exit Function
+    End If
+
+    ' Read project properties
+    Set GetDictionary = New Dictionary
+
+    Dim tdf As DAO.TableDef
+    Dim qdf As DAO.QueryDef
+    Dim cConnection As clsConnectionODBC
+    Dim dConnections As Scripting.Dictionary
+    
+    Set cConnection = New clsConnectionODBC
+    With CurrentDb
+        For Each tdf In .TableDefs
+            If StartsWith(tdf.Connect, "ODBC;", vbTextCompare) Then
+                cConnection.ParseOdbcConnectionString tdf.Connect
+                AddOdbcConnectionString GetDictionary, cConnection, tdf.Name
+            End If
+        Next
+        For Each qdf In .QueryDefs
+            If StartsWith(qdf.Connect, "ODBC;", vbTextCompare) Then
+                cConnection.ParseOdbcConnectionString qdf.Connect
+                AddOdbcConnectionString GetDictionary, cConnection, qdf.Name
+            End If
+        Next
+    End With
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : AddOdbcConnectionString
+' Author    : bclothier
+' Date      : 4/1/2023
+' Purpose   : The values of the GetDictionary are themselves a dictionary of the original
+'           : ODBC connection strings. This procedure helps handle creating a new
+'           : dictionary if there's not an entry for the sanitized connection string
+'           : already and then adds the original connection string under the key of
+'           : sanitized connection string.
+'---------------------------------------------------------------------------------------
+'
+Private Function AddOdbcConnectionString(dSanitizedConnections As Scripting.Dictionary, cConnection As clsConnectionODBC, strObjectName As String)
+    Dim dConnections As Scripting.Dictionary
+    
+    If dSanitizedConnections.Exists(cConnection.SanitizedConnectionString) Then
+        Set dConnections = dSanitizedConnections(cConnection.SanitizedConnectionString)
+    Else
+        Set dConnections = New Scripting.Dictionary
+        dConnections.CompareMode = TextCompare
+        dSanitizedConnections.Add cConnection.SanitizedConnectionString, dConnections
+    End If
+    If dConnections.Exists(cConnection.OriginalConnectionString) = False Then
+        dConnections.Add cConnection.OriginalConnectionString, strObjectName
+    End If
+End Function
+
+'---------------------------------------------------------------------------------------
+' Procedure : Merge
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Merge the source file into the existing database, updating or replacing
+'           : any existing object.
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_Merge(strFile As String)
+    ' Import if file exists
+    If FSO.FileExists(strFile) Then
+        IDbComponent_Import strFile
+    Else
+        VCSIndex.Remove Me, strFile
+    End If
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : IDbComponent_MoveSource
+' Author    : Adam Waller
+' Date      : 9/10/2022
+' Purpose   : Move the component's source file(s) from one folder to another
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_MoveSource(strFromFolder As String, strToFolder As String)
+    MoveFileIfExists strFromFolder & FSO.GetFileName(IDbComponent_SourceFile), strToFolder
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetAllFromDB
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a collection of class objects represented by this component type.
+'---------------------------------------------------------------------------------------
+'
+Private Function IDbComponent_GetAllFromDB(Optional blnModifiedOnly As Boolean = False) As Dictionary
+    If blnModifiedOnly = False Or m_dItems Is Nothing Then
+        Set m_dItems = GetDictionary
+    End If
+    
+    Dim dCollection As Scripting.Dictionary
+    Set dCollection = New Scripting.Dictionary
+    dCollection.Add "DbConnection", Me
+    
+    ' Return cached collection
+    Set IDbComponent_GetAllFromDB = dCollection
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : GetFileList
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a list of file names to import for this component type.
+'---------------------------------------------------------------------------------------
+'
+Private Function IDbComponent_GetFileList() As Dictionary
+    Set IDbComponent_GetFileList = New Dictionary
+    If FSO.FileExists(IDbComponent_SourceFile) Then IDbComponent_GetFileList.Add IDbComponent_SourceFile, vbNullString
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ClearOrphanedSourceFiles
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Remove any source files for objects not in the current database.
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_ClearOrphanedSourceFiles()
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ClearOrphanedDatabaseObjects
+' Author    : Adam Waller
+' Date      : 11/3/2021
+' Purpose   : Remove database objects that are not represented by existing source files.
+'---------------------------------------------------------------------------------------
+'
+Public Sub IDbComponent_ClearOrphanedDatabaseObjects()
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : IsModified
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Returns true if the object in the database has been modified since
+'           : the last export of the object.
+'---------------------------------------------------------------------------------------
+'
+Public Function IDbComponent_IsModified() As Boolean
+    IDbComponent_IsModified = VCSIndex.Item(Me).FileHash <> GetStringHash(GetSource, True)
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : DateModified
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : The date/time the object was modified. (If possible to retrieve)
+'           : If the modified date cannot be determined (such as application
+'           : properties) then this function will return 0.
+'---------------------------------------------------------------------------------------
+'
+Private Function IDbComponent_DateModified() As Date
+    IDbComponent_DateModified = 0
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : SourceModified
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : The date/time the source object was modified. In most cases, this would
+'           : be the date/time of the source file, but it some cases like SQL objects
+'           : the date can be determined through other means, so this function
+'           : allows either approach to be taken.
+'---------------------------------------------------------------------------------------
+'
+Private Function IDbComponent_SourceModified() As Date
+    If FSO.FileExists(IDbComponent_SourceFile) Then IDbComponent_SourceModified = GetLastModifiedDate(IDbComponent_SourceFile)
+End Function
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Category
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a category name for this type. (I.e. forms, queries, macros)
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_Category() As String
+    IDbComponent_Category = "Database Connections"
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : BaseFolder
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return the base folder for import/export of this component.
+'---------------------------------------------------------------------------------------
+Private Property Get IDbComponent_BaseFolder() As String
+    IDbComponent_BaseFolder = Options.GetExportFolder
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Name
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a name to reference the object for use in logs and screen output.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_Name() As String
+    IDbComponent_Name = "Database Connection"
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : SourceFile
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return the full path of the source file for the current object.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_SourceFile() As String
+    IDbComponent_SourceFile = IDbComponent_BaseFolder & "db-connection.json"
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Count
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Return a count of how many items are in this category.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_Count(Optional blnModifiedOnly As Boolean = False) As Long
+    IDbComponent_Count = IDbComponent_GetAllFromDB(blnModifiedOnly).Count
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : QuickCount
+' Author    : Adam Waller
+' Date      : 6/14/2022
+' Purpose   : Return a cached, non-iterative approximate count of database objects
+'           : for use with progress indicators when scanning for changes. Single file
+'           : objects like database properties can simply return 1.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_QuickCount() As Long
+    IDbComponent_QuickCount = 1
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : ComponentType
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : The type of component represented by this class.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_ComponentType() As eDatabaseComponentType
+    IDbComponent_ComponentType = edbConnection
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Upgrade
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Run any version specific upgrade processes before importing.
+'---------------------------------------------------------------------------------------
+'
+Private Sub IDbComponent_Upgrade()
+    ' No upgrade needed.
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : DbObject
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : This represents the database object we are dealing with.
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_DbObject() As Object
+    'Not applicable
+End Property
+Private Property Set IDbComponent_DbObject(ByVal RHS As Object)
+    'Not applicable
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : SingleFile
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Returns true if the export of all items is done as a single file instead
+'           : of individual files for each component. (I.e. properties, references)
+'---------------------------------------------------------------------------------------
+'
+Private Property Get IDbComponent_SingleFile() As Boolean
+    IDbComponent_SingleFile = True
+End Property
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Class_Initialize
+' Author    : Adam Waller
+' Date      : 5/17/2021
+' Purpose   : Helps us know whether we have already counted the objects.
+'---------------------------------------------------------------------------------------
+'
+Private Sub Class_Initialize()
+    'm_Count = -1
+End Sub
+
+
+'---------------------------------------------------------------------------------------
+' Procedure : Parent
+' Author    : Adam Waller
+' Date      : 4/24/2020
+' Purpose   : Return a reference to this class as an IDbComponent. This allows you
+'           : to reference the public methods of the parent class without needing
+'           : to create a new class object.
+'---------------------------------------------------------------------------------------
+'
+Public Property Get Parent() As IDbComponent
+    Set Parent = Me
+End Property
+
+

--- a/Version Control.accda.src/modules/modConstants.bas
+++ b/Version Control.accda.src/modules/modConstants.bas
@@ -76,6 +76,7 @@ Public Enum eDatabaseComponentType
     edbVbeProject
     edbVbeReference
     edbProject
+    edbConnection
 End Enum
 
 ' Error levels used for logging and monitoring the status

--- a/Version Control.accda.src/modules/modImportExport.bas
+++ b/Version Control.accda.src/modules/modImportExport.bas
@@ -407,6 +407,9 @@ Public Sub Build(strSourceFolder As String, blnFullBuild As Boolean, Optional in
 
     If DebugMode(True) Then On Error GoTo 0 Else On Error Resume Next
 
+    ' Close the previous cached connections, if any
+    CloseCachedConnections
+
     ' The type of build will be used in various messages and log entries.
     strType = IIf(blnFullBuild, "Build", "Merge")
 
@@ -629,7 +632,7 @@ Public Sub Build(strSourceFolder As String, blnFullBuild As Boolean, Optional in
     ' Reopen the database so the themes are loaded
     StageMainForm
     CloseCurrentDatabase2
-    OpenCurrentDatabase strPath
+    ShiftOpenDatabase strPath, False, Form_frmVCSMain
     RestoreMainForm
 
     ' Now we can initialize the form objects
@@ -652,6 +655,10 @@ Public Sub Build(strSourceFolder As String, blnFullBuild As Boolean, Optional in
         '    Perf.OperationEnd
         'End If
     End If
+
+    ' Close the cached connections, if any
+    CloseCachedConnections
+
     ' Log any errors after build/merge
     CatchAny eelError, "Error running " & CallByName(Options, "RunAfter" & strType, VbGet), ModuleName & ".Build", True, True
 

--- a/Version Control.accda.src/modules/modLibReference.bas
+++ b/Version Control.accda.src/modules/modLibReference.bas
@@ -9,15 +9,6 @@ Option Compare Database
 Option Private Module
 Option Explicit
 
-
-' API call to press shift key while opening the database to disable startup code
-' Need to use the keybd event call, not SetKeyboardState in order to support modern OS versions.
-Private Const KEYEVENTF_EXTENDEDKEY = &H1
-Private Const KEYEVENTF_KEYUP = &H2
-Private Const VK_SHIFT = &H10
-Private Declare PtrSafe Sub keybd_event Lib "user32" (ByVal bteVK As Byte, ByVal bteScan As Byte, ByVal dwFlags As Long, ByVal dwExtraInfo As Long)
-
-
 '---------------------------------------------------------------------------------------
 ' Procedure : LocalizeLibraryReferences
 ' Author    : Adam Waller
@@ -260,44 +251,4 @@ Private Sub FixReferences(dProject As Dictionary)
     Next varItem
 
 End Sub
-
-
-'---------------------------------------------------------------------------------------
-' Procedure : ShiftOpenDatabase
-' Author    : Adam Waller
-' Date      : 2/25/2022
-' Purpose   : Open a database with the shift key held down so we can (hopefully)
-'           : bypass the startup code.
-'---------------------------------------------------------------------------------------
-'
-Private Sub ShiftOpenDatabase(strPath As String, blnExclusive As Boolean, frmMain As Form_frmVCSMain)
-
-    ' Skip open if we are already on the correct database
-    If CurrentProject.FullName = strPath And Not blnExclusive Then Exit Sub
-
-    ' Close any open database before we try to open another one.
-    If DatabaseFileOpen Then
-        StageMainForm
-        Set frmMain = Nothing
-        CloseCurrentDatabase2
-        DoCmd.OpenForm "frmVCSMain", , , , , acHidden
-        Set frmMain = Form_frmVCSMain
-        RestoreMainForm
-    End If
-
-    ' Hold shift key down to bypass startup macro/form.
-    keybd_event VK_SHIFT, &H45, KEYEVENTF_EXTENDEDKEY Or 0, 0
-
-    ' Very important! Make sure the shift key actually goes down before opening the file.
-    Pause 0.5
-
-    ' Open the database
-    OpenCurrentDatabase strPath, blnExclusive
-
-    ' Restore the shift key
-    keybd_event VK_SHIFT, &H45, KEYEVENTF_EXTENDEDKEY Or KEYEVENTF_KEYUP, 0
-    DoEvents
-
-End Sub
-
 

--- a/Version Control.accda.src/modules/modVCSUtility.bas
+++ b/Version Control.accda.src/modules/modVCSUtility.bas
@@ -9,6 +9,13 @@ Option Compare Database
 Option Private Module
 Option Explicit
 
+' API call to press shift key while opening the database to disable startup code
+' Need to use the keybd event call, not SetKeyboardState in order to support modern OS versions.
+Private Const KEYEVENTF_EXTENDEDKEY = &H1
+Private Const KEYEVENTF_KEYUP = &H2
+Private Const VK_SHIFT = &H10
+Private Declare PtrSafe Sub keybd_event Lib "user32" (ByVal bteVK As Byte, ByVal bteScan As Byte, ByVal dwFlags As Long, ByVal dwExtraInfo As Long)
+
 Private Const ModuleName = "modVCSUtility"
 
 
@@ -35,6 +42,10 @@ Public Function GetContainers(Optional intFilter As eContainerFilter = ecfAllObj
 
             ' Primary case for processing all objects
             Case ecfAllObjects
+                If blnMDB Then
+                    ' Handle the connections early as possible but only for MDB formats
+                    .Add New clsDbConnection
+                End If
 
                 ' Shared objects in both MDB and ADP formats
                 .Add New clsDbProject
@@ -663,3 +674,42 @@ Public Sub CheckGitFiles()
     End If
 
 End Sub
+
+'---------------------------------------------------------------------------------------
+' Procedure : ShiftOpenDatabase
+' Author    : Adam Waller
+' Date      : 2/25/2022
+' Purpose   : Open a database with the shift key held down so we can (hopefully)
+'           : bypass the startup code.
+'---------------------------------------------------------------------------------------
+'
+Public Sub ShiftOpenDatabase(strPath As String, blnExclusive As Boolean, frmMain As Form_frmVCSMain)
+
+    ' Skip open if we are already on the correct database
+    If CurrentProject.FullName = strPath And Not blnExclusive Then Exit Sub
+
+    ' Close any open database before we try to open another one.
+    If DatabaseFileOpen Then
+        StageMainForm
+        Set frmMain = Nothing
+        CloseCurrentDatabase2
+        DoCmd.OpenForm "frmVCSMain", , , , , acHidden
+        Set frmMain = Form_frmVCSMain
+        RestoreMainForm
+    End If
+
+    ' Hold shift key down to bypass startup macro/form.
+    keybd_event VK_SHIFT, &H45, KEYEVENTF_EXTENDEDKEY Or 0, 0
+
+    ' Very important! Make sure the shift key actually goes down before opening the file.
+    Pause 0.5
+
+    ' Open the database
+    OpenCurrentDatabase strPath, blnExclusive
+
+    ' Restore the shift key
+    keybd_event VK_SHIFT, &H45, KEYEVENTF_EXTENDEDKEY Or KEYEVENTF_KEYUP, 0
+    DoEvents
+
+End Sub
+

--- a/Version Control.accda.src/tbldefs/tblConflicts.xml
+++ b/Version Control.accda.src/tbldefs/tblConflicts.xml
@@ -1,35 +1,36 @@
-﻿<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:od="urn:schemas-microsoft-com:officedata">
+﻿<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:od="urn:schemas-microsoft-com:officedata">
   <xsd:element name="dataroot">
     <xsd:complexType>
       <xsd:sequence>
-        <xsd:element ref="tblConflicts" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="tblConflicts" minOccurs="0" maxOccurs="unbounded"></xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="generated" type="xsd:dateTime"/>
+      <xsd:attribute name="generated" type="xsd:dateTime"></xsd:attribute>
     </xsd:complexType>
   </xsd:element>
   <xsd:element name="tblConflicts">
     <xsd:annotation>
       <xsd:appinfo>
-        <od:index index-name="ID" index-key="ID " primary="no" unique="no" clustered="no" order="asc"/>
-        <od:index index-name="ItemKey" index-key="ItemKey " primary="no" unique="no" clustered="no" order="asc"/>
-        <od:index index-name="PrimaryKey" index-key="ID " primary="yes" unique="yes" clustered="no" order="asc"/>
-        <od:tableProperty name="Orientation" type="2" value="0"/>
-        <od:tableProperty name="OrderByOn" type="1" value="0"/>
-        <od:tableProperty name="DefaultView" type="2" value="2"/>
-        <od:tableProperty name="DisplayViewsOnSharePointSite" type="2" value="1"/>
-        <od:tableProperty name="TotalsRow" type="1" value="0"/>
-        <od:tableProperty name="FilterOnLoad" type="1" value="0"/>
-        <od:tableProperty name="OrderByOnLoad" type="1" value="1"/>
-        <od:tableProperty name="HideNewField" type="1" value="0"/>
-        <od:tableProperty name="BackTint" type="6" value="100"/>
-        <od:tableProperty name="BackShade" type="6" value="100"/>
-        <od:tableProperty name="ThemeFontIndex" type="4" value="1"/>
-        <od:tableProperty name="AlternateBackThemeColorIndex" type="4" value="1"/>
-        <od:tableProperty name="AlternateBackTint" type="6" value="100"/>
-        <od:tableProperty name="AlternateBackShade" type="6" value="95"/>
-        <od:tableProperty name="ReadOnlyWhenDisconnected" type="1" value="0"/>
-        <od:tableProperty name="DatasheetGridlinesThemeColorIndex" type="4" value="3"/>
-        <od:tableProperty name="DatasheetForeThemeColorIndex" type="4" value="0"/>
+        <od:index index-name="ID" index-key="ID " primary="no" unique="no" clustered="no" order="asc"></od:index>
+        <od:index index-name="ItemKey" index-key="ItemKey " primary="no" unique="no" clustered="no" order="asc"></od:index>
+        <od:index index-name="PrimaryKey" index-key="ID " primary="yes" unique="yes" clustered="no" order="asc"></od:index>
+        <od:tableProperty name="Orientation" type="2" value="0"></od:tableProperty>
+        <od:tableProperty name="OrderByOn" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="DefaultView" type="2" value="2"></od:tableProperty>
+        <od:tableProperty name="DisplayViewsOnSharePointSite" type="2" value="1"></od:tableProperty>
+        <od:tableProperty name="TotalsRow" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="FilterOnLoad" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="OrderByOnLoad" type="1" value="1"></od:tableProperty>
+        <od:tableProperty name="HideNewField" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="BackTint" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="BackShade" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="ThemeFontIndex" type="4" value="1"></od:tableProperty>
+        <od:tableProperty name="AlternateBackThemeColorIndex" type="4" value="1"></od:tableProperty>
+        <od:tableProperty name="AlternateBackTint" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="AlternateBackShade" type="6" value="95"></od:tableProperty>
+        <od:tableProperty name="ReadOnlyWhenDisconnected" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="DatasheetGridlinesThemeColorIndex" type="4" value="3"></od:tableProperty>
+        <od:tableProperty name="DatasheetForeThemeColorIndex" type="4" value="0"></od:tableProperty>
       </xsd:appinfo>
     </xsd:annotation>
     <xsd:complexType>
@@ -37,193 +38,193 @@
         <xsd:element name="ID" minOccurs="1" od:jetType="autonumber" od:sqlSType="int" od:autoUnique="yes" od:nonNullable="yes" type="xsd:int">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="Component" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="255"/>
+              <xsd:maxLength value="255"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>
         <xsd:element name="ItemKey" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="255"/>
+              <xsd:maxLength value="255"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>
         <xsd:element name="FileName" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="2415"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="2415"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="255"/>
+              <xsd:maxLength value="255"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>
         <xsd:element name="ObjectDate" minOccurs="0" od:jetType="datetime" od:sqlSType="datetime" type="xsd:dateTime">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ShowDatePicker" type="3" value="1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ShowDatePicker" type="3" value="1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="IndexDate" minOccurs="0" od:jetType="datetime" od:sqlSType="datetime" type="xsd:dateTime">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ShowDatePicker" type="3" value="1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ShowDatePicker" type="3" value="1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="FileDate" minOccurs="0" od:jetType="datetime" od:sqlSType="datetime" type="xsd:dateTime">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ShowDatePicker" type="3" value="1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ShowDatePicker" type="3" value="1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="Suggestion" minOccurs="0" od:jetType="longinteger" od:sqlSType="int" type="xsd:int">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="DecimalPlaces" type="2" value="255"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DecimalPlaces" type="2" value="255"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="Resolution" minOccurs="0" od:jetType="longinteger" od:sqlSType="int" type="xsd:int">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="DecimalPlaces" type="2" value="255"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DecimalPlaces" type="2" value="255"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
         </xsd:element>
         <xsd:element name="Diff" minOccurs="0" od:jetType="hyperlink" od:sqlSType="ntext" od:hyperlink="yes">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="DefaultValue" type="12" value="&quot;Show Diff...&quot;"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AppendOnly" type="1" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DefaultValue" type="12" value="&quot;Show Diff...&quot;"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AppendOnly" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="536870910"/>
+              <xsd:maxLength value="536870910"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>

--- a/Version Control.accda.src/tbldefs/tblResources.xml
+++ b/Version Control.accda.src/tbldefs/tblResources.xml
@@ -1,34 +1,35 @@
-﻿<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:od="urn:schemas-microsoft-com:officedata">
+﻿<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:od="urn:schemas-microsoft-com:officedata">
   <xsd:element name="dataroot">
     <xsd:complexType>
       <xsd:sequence>
-        <xsd:element ref="tblResources" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="tblResources" minOccurs="0" maxOccurs="unbounded"></xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="generated" type="xsd:dateTime"/>
+      <xsd:attribute name="generated" type="xsd:dateTime"></xsd:attribute>
     </xsd:complexType>
   </xsd:element>
   <xsd:element name="tblResources">
     <xsd:annotation>
       <xsd:appinfo>
-        <od:index index-name="ID" index-key="ResourceName " primary="no" unique="no" clustered="no" order="asc"/>
-        <od:index index-name="PrimaryKey" index-key="ResourceName " primary="yes" unique="yes" clustered="no" order="asc"/>
-        <od:tableProperty name="Orientation" type="2" value="0"/>
-        <od:tableProperty name="OrderByOn" type="1" value="0"/>
-        <od:tableProperty name="DefaultView" type="2" value="2"/>
-        <od:tableProperty name="DisplayViewsOnSharePointSite" type="2" value="1"/>
-        <od:tableProperty name="TotalsRow" type="1" value="0"/>
-        <od:tableProperty name="FilterOnLoad" type="1" value="0"/>
-        <od:tableProperty name="OrderByOnLoad" type="1" value="1"/>
-        <od:tableProperty name="HideNewField" type="1" value="0"/>
-        <od:tableProperty name="BackTint" type="6" value="100"/>
-        <od:tableProperty name="BackShade" type="6" value="100"/>
-        <od:tableProperty name="ThemeFontIndex" type="4" value="1"/>
-        <od:tableProperty name="AlternateBackThemeColorIndex" type="4" value="1"/>
-        <od:tableProperty name="AlternateBackTint" type="6" value="100"/>
-        <od:tableProperty name="AlternateBackShade" type="6" value="95"/>
-        <od:tableProperty name="ReadOnlyWhenDisconnected" type="1" value="0"/>
-        <od:tableProperty name="DatasheetGridlinesThemeColorIndex" type="4" value="3"/>
-        <od:tableProperty name="DatasheetForeThemeColorIndex" type="4" value="0"/>
+        <od:index index-name="ID" index-key="ResourceName " primary="no" unique="no" clustered="no" order="asc"></od:index>
+        <od:index index-name="PrimaryKey" index-key="ResourceName " primary="yes" unique="yes" clustered="no" order="asc"></od:index>
+        <od:tableProperty name="Orientation" type="2" value="0"></od:tableProperty>
+        <od:tableProperty name="OrderByOn" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="DefaultView" type="2" value="2"></od:tableProperty>
+        <od:tableProperty name="DisplayViewsOnSharePointSite" type="2" value="1"></od:tableProperty>
+        <od:tableProperty name="TotalsRow" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="FilterOnLoad" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="OrderByOnLoad" type="1" value="1"></od:tableProperty>
+        <od:tableProperty name="HideNewField" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="BackTint" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="BackShade" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="ThemeFontIndex" type="4" value="1"></od:tableProperty>
+        <od:tableProperty name="AlternateBackThemeColorIndex" type="4" value="1"></od:tableProperty>
+        <od:tableProperty name="AlternateBackTint" type="6" value="100"></od:tableProperty>
+        <od:tableProperty name="AlternateBackShade" type="6" value="95"></od:tableProperty>
+        <od:tableProperty name="ReadOnlyWhenDisconnected" type="1" value="0"></od:tableProperty>
+        <od:tableProperty name="DatasheetGridlinesThemeColorIndex" type="4" value="3"></od:tableProperty>
+        <od:tableProperty name="DatasheetForeThemeColorIndex" type="4" value="0"></od:tableProperty>
       </xsd:appinfo>
     </xsd:annotation>
     <xsd:complexType>
@@ -36,38 +37,38 @@
         <xsd:element name="ResourceName" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="2925"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="1"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="2925"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="255"/>
+              <xsd:maxLength value="255"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>
         <xsd:element name="Content" minOccurs="0" od:jetType="complex" od:jetComplexType="MSysComplexType_Attachment" maxOccurs="unbounded">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="126"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="126"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:complexType>
@@ -75,30 +76,30 @@
               <xsd:element name="FileData" minOccurs="0" od:jetType="oleobject" od:sqlSType="image">
                 <xsd:simpleType>
                   <xsd:restriction base="xsd:base64Binary">
-                    <xsd:maxLength value="1476395008"/>
+                    <xsd:maxLength value="1476395008"></xsd:maxLength>
                   </xsd:restriction>
                 </xsd:simpleType>
               </xsd:element>
-              <xsd:element name="FileFlags" minOccurs="0" od:jetType="longinteger" od:sqlSType="int" type="xsd:int"/>
+              <xsd:element name="FileFlags" minOccurs="0" od:jetType="longinteger" od:sqlSType="int" type="xsd:int"></xsd:element>
               <xsd:element name="FileName" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
                 <xsd:simpleType>
                   <xsd:restriction base="xsd:string">
-                    <xsd:maxLength value="255"/>
+                    <xsd:maxLength value="255"></xsd:maxLength>
                   </xsd:restriction>
                 </xsd:simpleType>
               </xsd:element>
-              <xsd:element name="FileTimeStamp" minOccurs="0" od:jetType="datetime" od:sqlSType="datetime" type="xsd:dateTime"/>
+              <xsd:element name="FileTimeStamp" minOccurs="0" od:jetType="datetime" od:sqlSType="datetime" type="xsd:dateTime"></xsd:element>
               <xsd:element name="FileType" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
                 <xsd:simpleType>
                   <xsd:restriction base="xsd:string">
-                    <xsd:maxLength value="255"/>
+                    <xsd:maxLength value="255"></xsd:maxLength>
                   </xsd:restriction>
                 </xsd:simpleType>
               </xsd:element>
               <xsd:element name="FileURL" minOccurs="0" od:jetType="memo" od:sqlSType="ntext">
                 <xsd:simpleType>
                   <xsd:restriction base="xsd:string">
-                    <xsd:maxLength value="536870910"/>
+                    <xsd:maxLength value="536870910"></xsd:maxLength>
                   </xsd:restriction>
                 </xsd:simpleType>
               </xsd:element>
@@ -108,24 +109,24 @@
         <xsd:element name="Description" minOccurs="0" od:jetType="text" od:sqlSType="nvarchar">
           <xsd:annotation>
             <xsd:appinfo>
-              <od:fieldProperty name="ColumnWidth" type="3" value="-1"/>
-              <od:fieldProperty name="ColumnOrder" type="3" value="0"/>
-              <od:fieldProperty name="ColumnHidden" type="1" value="0"/>
-              <od:fieldProperty name="Required" type="1" value="0"/>
-              <od:fieldProperty name="AllowZeroLength" type="1" value="1"/>
-              <od:fieldProperty name="DisplayControl" type="3" value="109"/>
-              <od:fieldProperty name="IMEMode" type="2" value="0"/>
-              <od:fieldProperty name="IMESentenceMode" type="2" value="3"/>
-              <od:fieldProperty name="UnicodeCompression" type="1" value="1"/>
-              <od:fieldProperty name="TextAlign" type="2" value="0"/>
-              <od:fieldProperty name="AggregateType" type="4" value="-1"/>
-              <od:fieldProperty name="ResultType" type="2" value="0"/>
-              <od:fieldProperty name="CurrencyLCID" type="4" value="0"/>
+              <od:fieldProperty name="ColumnWidth" type="3" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ColumnOrder" type="3" value="0"></od:fieldProperty>
+              <od:fieldProperty name="ColumnHidden" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="Required" type="1" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AllowZeroLength" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="DisplayControl" type="3" value="109"></od:fieldProperty>
+              <od:fieldProperty name="IMEMode" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="IMESentenceMode" type="2" value="3"></od:fieldProperty>
+              <od:fieldProperty name="UnicodeCompression" type="1" value="1"></od:fieldProperty>
+              <od:fieldProperty name="TextAlign" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="AggregateType" type="4" value="-1"></od:fieldProperty>
+              <od:fieldProperty name="ResultType" type="2" value="0"></od:fieldProperty>
+              <od:fieldProperty name="CurrencyLCID" type="4" value="0"></od:fieldProperty>
             </xsd:appinfo>
           </xsd:annotation>
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="255"/>
+              <xsd:maxLength value="255"></xsd:maxLength>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>

--- a/Version Control.accda.src/vbe-project.json
+++ b/Version Control.accda.src/vbe-project.json
@@ -5,7 +5,7 @@
   },
   "Items": {
     "Name": "MSAccessVCS",
-    "Description": "Version 4.0.9 deployed on 3/6/2023",
+    "Description": "Version 4.1.0 deployed on 4/1/2023",
     "FileName": "Version Control.accda",
     "HelpFile": "",
     "HelpContextId": 0,

--- a/Version Control.accda.src/vcs-options.json
+++ b/Version Control.accda.src/vcs-options.json
@@ -1,6 +1,6 @@
 ﻿{
   "Info": {
-    "AddinVersion": "4.0.9",
+    "AddinVersion": "4.1.0",
     "AccessVersion": "14.0 32-bit"
   },
   "Options": {


### PR DESCRIPTION
This has three main improvements which I needed to be able to use the add-in. The version 4.0.9 could not handle the tables that had either attachments or Binary fields and from my testing, it appears that like the calculated fields, the schema needs to be included to allow the add-in to correctly import tables with such fields. Thus, the `modSanitize` module has been updated to check for those 3 cases and include schema. This does unfortunately mean slightly bigger source files for those tables but at the moment that was the simplest way to enable importing such tables and retain their data. 

The 2nd thing is to change the import routine to use `ShiftOpenDatabase` function because when the add-in restarts the file to load the theme, it opens the database normally, which would run the startup code in place which cause problems because we now have startup code running with the import code still running, which can make a mess of things. 

The last and biggest thing is to support Access applications that works with ODBC backends. As a matter of best practice, we do not embed passwords and we don't always have the luxury of having a trusted connection. In those situations, importing source files can led to multiple and repeated ODBC login prompts which is really annoying and slow.  We avoid this problem by priming Access' internal cache first before we attempt to import. [In case, one is unfamiliar with this, this article gives some information](https://www.microsoft.com/en-us/microsoft-365/blog/2011/04/08/power-tip-improve-the-security-of-database-connections/). 

By priming the connection, we can perform the necessary logins only once per "unique" connection string before the actual imports start which result in much smooth import experience for those projects. In theory, cancelling should stop the import but I have not yet decided on best UX for handling both user's cancelling out or when user makes mistake and fail to complete the connection which may need retrying. That will be addressed in a separate PR. 

To handle this, a new category has been introduced, `clsDbConnection` with the corresponding source file `db-connection.json`. Being a `IDBComponent` means it "imports" and "exports" even though technically its data is a derivative from the data already present in other objects (mainly the tabledefs and querydefs). However, it's necessary to have this in a source file so that the import can be done without having to parse the source files for all connection strings that exists. 